### PR TITLE
feature 254

### DIFF
--- a/cmd/flex/main/cli.go
+++ b/cmd/flex/main/cli.go
@@ -626,13 +626,13 @@ func readConfig(configFile string) (resources.UbiquityPluginConfig, error) {
 }
 
 func setupLogger(logPath string) (*log.Logger, *os.File) {
-	logFile, err := os.OpenFile(path.Join(logPath, k8sresources.UbiquityFlexLogFileName), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
+	logFile, err := os.OpenFile(path.Join(logPath, k8sresources.UbiquityFlexLogFileName), os.O_WRONLY|os.O_CREATE, 0640)
 	if err != nil {
 		fmt.Printf("Failed to setup logger: %s\n", err.Error())
 		return nil, nil
 	}
 	log.SetOutput(logFile)
-	logger := log.New(io.MultiWriter(logFile), "ubiquity-flexvolume: ", log.Lshortfile|log.LstdFlags)
+	logger := log.New(io.MultiWriter(logFile, os.Stdout), "ubiquity-flexvolume: ", log.Lshortfile|log.LstdFlags)
 	return logger, logFile
 }
 


### PR DESCRIPTION
Remove os.o_append, so that the logs in log file will be overwrite, and it will not go into fat issue.
Since I have some issue with my ubiquity build ENV, I tested in a simple file, however I will try to build the ubiquity build and verify the ubiquity logs out put

Test Code:

package main

import (
"fmt"
"io"
"log"
"os"
"path"
)

func SetupLogger(logPath string, loggerName string) (*log.Logger, *os.File) {
logFile, err := os.OpenFile(path.Join(logPath, fmt.Sprintf("%s.log", loggerName)), os.O_WRONLY|os.O_CREATE, 0640)
if err != nil {
fmt.Printf("Failed to setup logger: %s\n", err.Error())
return nil, nil
}
log.SetOutput(logFile)
logger := log.New(io.MultiWriter(os.Stdout, logFile), fmt.Sprintf("%s: ", loggerName), log.Lshortfile|log.LstdFlags)
return logger, logFile
}

func CloseLogs(logFile *os.File) {
logFile.Sync()
logFile.Close()
}
func main(){
logger, logFile := SetupLogger("/tmp/test", "testlog")
logger.Printf("Provisioner %s specified", logFile)
logger.Printf("aaaa %s", logFile)
logger.Printf("bbbb %s", logFile)
logger.Printf("cccc %s", logFile)
logger.Printf("dddd %s", logFile)
CloseLogs(logFile)
}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/114)
<!-- Reviewable:end -->
