### PR TITLE
Flex daemonset should set to RollingUpdate to enable easy image updat…

### DIFF
--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
@@ -6,6 +6,8 @@ metadata:
     app: ubiquity-k8s-flex
     product: ibm-storage-enabler-for-containers
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Yu Dai just found out that by default the daemonset updatestrategy is not rolling updates, means if u upgrade the flex image you need to kill flex pod by pod instead of just update the daemonset.
So this PR is to set the daemonset by default for rolling update to simplify the upgrade flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/149)
<!-- Reviewable:end -->
