### PR TITLE
Flex logs must NOT exist on the plugin directory, uses /tmp instead

### DIFF
--- a/deploy/k8s_deployments/setup_flex.sh
+++ b/deploy/k8s_deployments/setup_flex.sh
@@ -127,6 +127,7 @@ VENDOR=ibm
 DRIVER=ubiquity-k8s-flex
 DRIVER_DIR=${VENDOR}"~"${DRIVER}
 HOST_K8S_PLUGIN_DIR=/usr/libexec/kubernetes/kubelet-plugins/volume/exec   # Assume the host-path to the kubelet-plugins directory is mounted here
+LOG_DIR=/tmp
 MNT_FLEX=${HOST_K8S_PLUGIN_DIR}
 MNT_FLEX_DRIVER_DIR=${MNT_FLEX}/${DRIVER_DIR}
 FLEX_CONF=${DRIVER}.conf
@@ -139,16 +140,17 @@ install_flex_trusted_ca
 
 echo "Finished to deploy the flex driver [$DRIVER], config file and its certificate into the host path ${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}"
 echo ""
+/usr/sbin/logrotate /etc/logrotate.d/ubiquity_logrotate
 
 test_flex_driver
 
 echo ""
-echo "This Pod will handle log rotation for the <flex log> on the host [${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}/${DRIVER}.log]"
+echo "This Pod will handle log rotation for the <flex log> on the host [${LOG_DIR}/${DRIVER}.log]"
 echo "Running in the background tail -F <flex log>, so the log will be visible though kubectl logs <flex POD>"
 echo "[`date`] Start to run in background #>"
-echo "tail -F ${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}/${DRIVER}.log"
+echo "tail -F ${LOG_DIR}/${DRIVER}.log"
 echo "-----------------------------------------------"
-tail -F ${MNT_FLEX_DRIVER_DIR}/ubiquity-k8s-flex.log &
+tail -F ${LOG_DIR}/${DRIVER}.log &
 
 while : ; do
   sleep 86400 # every 24 hours

--- a/deploy/k8s_deployments/setup_flex.sh
+++ b/deploy/k8s_deployments/setup_flex.sh
@@ -127,7 +127,7 @@ VENDOR=ibm
 DRIVER=ubiquity-k8s-flex
 DRIVER_DIR=${VENDOR}"~"${DRIVER}
 HOST_K8S_PLUGIN_DIR=/usr/libexec/kubernetes/kubelet-plugins/volume/exec   # Assume the host-path to the kubelet-plugins directory is mounted here
-LOG_DIR=/tmp
+LOG_DIR=${HOST_K8S_PLUGIN_DIR}
 MNT_FLEX=${HOST_K8S_PLUGIN_DIR}
 MNT_FLEX_DRIVER_DIR=${MNT_FLEX}/${DRIVER_DIR}
 FLEX_CONF=${DRIVER}.conf
@@ -140,7 +140,6 @@ install_flex_trusted_ca
 
 echo "Finished to deploy the flex driver [$DRIVER], config file and its certificate into the host path ${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}"
 echo ""
-/usr/sbin/logrotate /etc/logrotate.d/ubiquity_logrotate
 
 test_flex_driver
 

--- a/deploy/k8s_deployments/ubiquity_logrotate
+++ b/deploy/k8s_deployments/ubiquity_logrotate
@@ -1,4 +1,4 @@
-/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ubiquity-k8s-flex/ubiquity-k8s-flex.log {
+/tmp/ubiquity-k8s-flex.log {
     su root root
     size 50M
     daily

--- a/deploy/k8s_deployments/ubiquity_logrotate
+++ b/deploy/k8s_deployments/ubiquity_logrotate
@@ -1,6 +1,6 @@
-/tmp/ubiquity-k8s-flex.log {
+/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ubiquity-k8s-flex.log {
     su root root
-    size 50M
+    size 20M
     daily
     rotate 5
     copytruncate 

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
@@ -70,7 +70,6 @@ spec:
 
 
 
-        imagePullPolicy: Always
         command: ["./setup_flex.sh"]
         volumeMounts:
         - name: host-k8splugindir


### PR DESCRIPTION
This PR fix the multiple flex initialization on k8s 1.8.

Since the flex log file was targeted on the  plugin directory (-/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ubiquity-k8s-flex/ubiquity-k8s-flex.log), and k8s 1.8 support automatic reloading flex, while writting to the log the kubelet was recognize change in the plugin directory and execute init.
so its not good to locate the flex log file in the flex directory. Therefor the fix is just to create the flex log file under /tmp (of cause also the log rotate will use /tmp as well)

Thanks Chakravarthy for helping me to identify the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/153)
<!-- Reviewable:end -->
