### PR TITLE
Fix: Silent any logging coming from Flex GetVolumeName action (Should…

### DIFF
--- a/cmd/flex/main/cli.go
+++ b/cmd/flex/main/cli.go
@@ -71,40 +71,11 @@ type GetVolumeNameCommand struct {
 }
 
 func (g *GetVolumeNameCommand) Execute(args []string) error {
-	if len(args) < 1 {
-
-		response := k8sresources.FlexVolumeResponse{
-			Status:  "Failure",
-			Message: fmt.Sprintf("Not enough arguments to getVolumeName call out"),
-		}
-		return printResponse(response)
+	// This GetVolumeName action in FlexVolume CLI is not relevant, we can just return not supported without logging anything.
+	response := k8sresources.FlexVolumeResponse{
+		Status: "Not supported",
 	}
-	getVolumeNameRequestOpts := make(map[string]string)
-	err := json.Unmarshal([]byte(args[0]), &getVolumeNameRequestOpts)
-	if err != nil {
-		response := k8sresources.FlexVolumeResponse{
-			Status:  "Failure",
-			Message: fmt.Sprintf("Failed to read args in get volumeName %#v", err),
-		}
-		return printResponse(response)
-	}
-	config, err := readConfig(*configFile)
-	if err != nil {
-		response := k8sresources.FlexVolumeResponse{
-			Status:  "Failure",
-			Message: fmt.Sprintf("Failed to read config in get volumeName %#v", err),
-		}
-		return printResponse(response)
-	}
-	defer logs.InitFileLogger(logs.GetLogLevelFromString(config.LogLevel), path.Join(config.LogPath, k8sresources.UbiquityFlexLogFileName))()
-	controller, err := createController(config)
-
-	if err != nil {
-		panic(fmt.Sprintf("backend %s not found", config))
-	}
-	getVolumeNameRequest := k8sresources.FlexVolumeGetVolumeNameRequest{Opts: getVolumeNameRequestOpts}
-	getVolumeNameResponse := controller.GetVolumeName(getVolumeNameRequest)
-	return printResponse(getVolumeNameResponse)
+	return printResponse(response)
 }
 
 //AttachCommand attaches a volume to a node


### PR DESCRIPTION
Currently the flexvolume getting many calls for getVolumeName (every few seconds\minutes). And the flexdirver produce a lot of DEBUG and INFO message to the flex log file on every call.
Eventually our flex driver just return Not Supported for this API. 

Chakry and Cheng approved that this getVolumeName is getting call by k8s, but flexdriver just need to response with "not supported".
So this PR is to reduce all logging regarding this getVolumeName call, to make the flex log file from all the getVolumeName logging noise.

The call should just return not supported without doing any logging to the flex log.

This PR reduce the following log lines:

> 2018-03-11 10:06:15.3 INFO 8605 client_init.go:95 remote::initialize Client SSL Mode set to [require]. Attention: the communication to ubiquity is InsecureSkipVerify []
> 2018-03-11 10:06:15.3 INFO 8605 client_init.go:102 remote::initialize  [[{url=https://10.109.100.171:9999/ubiquity_storage} {CA=/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ubiquity-k8s-flex/ubiquity-trusted-ca.crt}]]
> 2018-03-11 10:06:15.301 DEBUG 8605 controller.go:149 controller::GetVolumeName ENTER []
> 2018-03-11 10:06:15.301 DEBUG 8605 controller.go:151 controller::GetVolumeName  [[{request={map[PhysicalCapacity:20468203520 StorageName:XIV Gen4d-67d kubernetes.io/fsType: kubernetes.io/readwrite:rw UsedCapacity:0 Wwn:WWNX fstype:ext4 kubernetes.io/pvOrVolumeName:ibm-ubiquity-db LogicalCapacity:20000000000 Name:u_instance1_ibm-ubiquity-db Profile:gold StorageType:2810XIV attach-to: volumeName:ibm-ubiquity-db PoolName:gold-shay-ubiquiyt]}}]]
> 2018-03-11 10:06:15.301 DEBUG 8605 controller.go:157 controller::GetVolumeName  [[{response={Not supported    false}}]]
> 2018-03-11 10:06:15.301 DEBUG 8605 controller.go:158 controller::GetVolumeName EXIT []
> 
> 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/158)
<!-- Reviewable:end -->
