### PR TITLE
fix/UB-590_flex_log_is_not_compressed

### DIFF
--- a/deploy/k8s_deployments/ubiquity_logrotate
+++ b/deploy/k8s_deployments/ubiquity_logrotate
@@ -3,6 +3,7 @@
     size 50M
     daily
     rotate 5
+    compress
     copytruncate 
     create 0600 root root
 }


### PR DESCRIPTION
To compress the flex log to save the disk space
Signed-off-by: feihuang <feihuang@feihuangs-mbp.cn.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/159)
<!-- Reviewable:end -->
