### PR TITLE
UB-624: flex log design change

### DIFF
--- a/deploy/k8s_deployments/setup_flex.sh
+++ b/deploy/k8s_deployments/setup_flex.sh
@@ -7,7 +7,7 @@
 #    /usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ubiquity-k8s-flex
 # 2. Run tail -f on the flex log file, so it will be visible via kubectl logs <flex Pod>
 # 3. Start infinite loop with logrotate every 24 hours on the host flex log file
-#    /usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ubiquity-k8s-flex/ubiquity-k8s-flex.log
+#    /tmp/log/ubiquity/ubiquity-k8s-flex.log
 #    The rotation policy is based on /etc/logrotate.d/ubiquity_logrotate
 ###########################################################################
 
@@ -26,6 +26,15 @@ function install_flex_driver()
     echo "Copying the flex driver ~/$DRIVER into ${MNT_FLEX_DRIVER_DIR} directory."
     cp ~/$DRIVER "${MNT_FLEX_DRIVER_DIR}/.$DRIVER"
     mv -f "${MNT_FLEX_DRIVER_DIR}/.$DRIVER" "${MNT_FLEX_DRIVER_DIR}/$DRIVER"
+}
+
+function create_flex_log_dir()
+{
+    # Create /tmp/log/ubiquity directory
+    if [ ! -d "${FLEX_LOG_DIR}" ]; then
+       echo "Creating the flex log directory [$FLEX_LOG_DIR] for the first time."
+       mkdir "${FLEX_LOG_DIR}"
+    fi
 }
 
 function generate_flex_conf_from_envs_and_install_it()
@@ -53,7 +62,7 @@ function generate_flex_conf_from_envs_and_install_it()
     cat > $FLEX_TMP << EOF
 # This file was generated automatically by the $DRIVER Pod.
 
-logPath = "${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}"
+logPath = "${FLEX_LOG_DIR}"
 backends = ["$UBIQUITY_BACKEND"]
 logLevel = "$LOG_LEVEL"
 
@@ -82,7 +91,7 @@ function test_flex_driver()
 {
     echo "Test the flex driver by running $> ${MNT_FLEX_DRIVER_DIR}/$DRIVER testubiquity"
     testubiquity=`${MNT_FLEX_DRIVER_DIR}/$DRIVER testubiquity 2>&1`
-    flex_log=${MNT_FLEX_DRIVER_DIR}/ubiquity-k8s-flex.log
+    flex_log=${FLEX_LOG_DIR}/ubiquity-k8s-flex.log
     if echo "$testubiquity" | grep '"status":"Success"' >/dev/null; then
        echo "$testubiquity"
        echo "Flex test passed Ok"
@@ -130,10 +139,12 @@ HOST_K8S_PLUGIN_DIR=/usr/libexec/kubernetes/kubelet-plugins/volume/exec   # Assu
 MNT_FLEX=${HOST_K8S_PLUGIN_DIR}
 MNT_FLEX_DRIVER_DIR=${MNT_FLEX}/${DRIVER_DIR}
 FLEX_CONF=${DRIVER}.conf
+FLEX_LOG_DIR=/tmp/log/ubiquity
 
 echo "[`date`]"
 echo "Starting $DRIVER Pod..."
 install_flex_driver
+create_flex_log_dir
 generate_flex_conf_from_envs_and_install_it
 install_flex_trusted_ca
 
@@ -143,12 +154,12 @@ echo ""
 test_flex_driver
 
 echo ""
-echo "This Pod will handle log rotation for the <flex log> on the host [${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}/${DRIVER}.log]"
+echo "This Pod will handle log rotation for the <flex log> on the host [${FLEX_LOG_DIR}/${DRIVER}.log]"
 echo "Running in the background tail -F <flex log>, so the log will be visible though kubectl logs <flex POD>"
 echo "[`date`] Start to run in background #>"
-echo "tail -F ${HOST_K8S_PLUGIN_DIR}/${DRIVER_DIR}/${DRIVER}.log"
+echo "tail -F ${FLEX_LOG_DIR}/${DRIVER}.log"
 echo "-----------------------------------------------"
-tail -F ${MNT_FLEX_DRIVER_DIR}/ubiquity-k8s-flex.log &
+tail -F ${FLEX_LOG_DIR}/ubiquity-k8s-flex.log &
 
 while : ; do
   sleep 86400 # every 24 hours

--- a/deploy/k8s_deployments/ubiquity_logrotate
+++ b/deploy/k8s_deployments/ubiquity_logrotate
@@ -1,4 +1,4 @@
-/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ubiquity-k8s-flex/ubiquity-k8s-flex.log {
+/tmp/log/ubiquity/ubiquity-k8s-flex.log {
     su root root
     size 50M
     rotate 5

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
@@ -74,6 +74,8 @@ spec:
         volumeMounts:
         - name: host-k8splugindir
           mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+        - name: flex-logdir
+          mountPath: /tmp/log/ubiquity
 # Certificate Set : use the below volumeMounts only if predefine certificate given
 # Cert #        - name: ubiquity-public-certificates
 # Cert #          mountPath: /var/lib/ubiquity/ssl/public
@@ -83,6 +85,9 @@ spec:
       - name: host-k8splugindir
         hostPath:
           path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec  # This directory must exist on the host
+      - name: flex-logdir
+        hostPath:
+          path: /tmp/log/ubiquity
 # Certificate Set : use the below volumes only if predefine certificate given
 # Cert #      - name: ubiquity-public-certificates
 # Cert #        configMap:


### PR DESCRIPTION
change log path to /tmp/log/ubiquity

Signed-off-by: feihuang <feihuang@feihuangs-mbp.cn.ibm.com>

2. Option
change log to /var/logs
Mandatory ask for adding /var/logs for controller-manager
        Fei: we create /tmp/log/ubiquity in code, so don't need to ask customer to create this
Anyway daemonset upgrade yml is needed
Less coding, and no new go utility(no Legal)

work with https://github.com/IBM/ubiquity/pull/182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/164)
<!-- Reviewable:end -->
