### PR TITLE
Feature/upgrade and set to alpine3.7 and openssl

### DIFF
--- a/Dockerfile.Flex
+++ b/Dockerfile.Flex
@@ -6,8 +6,8 @@ RUN glide up --strip-vendor
 RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode external -extldflags "-static"' -installsuffix cgo -o ubiquity-k8s-flex cmd/flex/main/cli.go
 
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM alpine:3.7
+RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2n-r0
 RUN apk --update add logrotate
 ENV UBIQUITY_PLUGIN_VERIFY_CA=/var/lib/ubiquity/ssl/public/ubiquity-trusted-ca.crt
 WORKDIR /root/

--- a/Dockerfile.Flex
+++ b/Dockerfile.Flex
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode 
 
 
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2n-r0
+RUN apk --no-cache add ca-certificates=20171114-r0
 RUN apk --update add logrotate
 ENV UBIQUITY_PLUGIN_VERIFY_CA=/var/lib/ubiquity/ssl/public/ubiquity-trusted-ca.crt
 WORKDIR /root/

--- a/Dockerfile.Provisioner
+++ b/Dockerfile.Provisioner
@@ -6,8 +6,8 @@ RUN glide up --strip-vendor
 RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode external -extldflags "-static"' -installsuffix cgo -o ubiquity-k8s-provisioner cmd/provisioner/main/main.go
 
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM alpine:3.7
+RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2n-r0
 ENV UBIQUITY_PLUGIN_VERIFY_CA=/var/lib/ubiquity/ssl/public/ubiquity-trusted-ca.crt
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity-k8s/ubiquity-k8s-provisioner .

--- a/Dockerfile.Provisioner
+++ b/Dockerfile.Provisioner
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode 
 
 
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2n-r0
+RUN apk --no-cache add ca-certificates=20171114-r0
 ENV UBIQUITY_PLUGIN_VERIFY_CA=/var/lib/ubiquity/ssl/public/ubiquity-trusted-ca.crt
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity-k8s/ubiquity-k8s-provisioner .

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
+  version: dev
   subpackages:
   - remote
   - resources


### PR DESCRIPTION
1. ubiquity-k8s-flex and ubiquity-k8s-provisioner base images in GA v1.0 was set to alpine:latest (back then it was alpine version 3.6). We should not use "latest" tag in Dockerfile any more, so I set it to alpine:3.7 which is now the latest alpine version. So this PR set specific alpine tag version and also upgrade to 3.7 compare to GA v1.0.

2. In addition setting specific version for ca-certificates  to 20171114-r0

**How to test**
1. Install ubiquity and then jump inside the flex and provisioner pods and check the new alpine version 
`#> kubectl exec -n ubiquity -it <POD> -- cat /etc/alpine-release`
In addition check the new packages version 
`#> kubectl exec -n ubiquity -it <POD> -- apk info -v | egrep "ca-cert`
(You can also use the google image tool for testing it)

This PR is similar to ubiquity server PR that upgrade to alpine 3.8 openssl and also ca-certificates for the ubiqutiy server base image -> https://github.com/IBM/ubiquity/pull/189.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/170)
<!-- Reviewable:end -->
