### PR TITLE
SCBE rebrand left overs + set to version 1.1.0 in ubiqutiy_installer.conf

### DIFF
--- a/scripts/installer-for-ibm-storage-enabler-for-containers/scbe-credentials-secret.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/scbe-credentials-secret.yml
@@ -4,11 +4,11 @@ metadata:
   name: scbe-credentials
   labels:
     product: ibm-storage-enabler-for-containers
-# SCBE credentials needed for ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset.
+# Spectrum Connect(SCBE) credentials needed for ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset.
 type: Opaque
 data:
-   # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in SCBE.
+   # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
    username: "SCBE_USERNAME_VALUE"
 
-   # Base64-encoded password defined for the IBM Storage Enabler for Containers interface in SCBE.
+   # Base64-encoded password defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
    password: "SCBE_PASSWORD_VALUE"

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/scbe-credentials-secret.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/scbe-credentials-secret.yml
@@ -4,7 +4,7 @@ metadata:
   name: scbe-credentials
   labels:
     product: ibm-storage-enabler-for-containers
-# Spectrum Connect(SCBE) credentials needed for ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset.
+# Spectrum Connect(previously known as SCBE) credentials needed for ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset.
 type: Opaque
 data:
    # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity-configmap.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity-configmap.yml
@@ -8,7 +8,7 @@ metadata:
 data:
    # The keys below are used by ubiquity deployment
    # -----------------------------------------------
-   # IP or FQDN of Spectrum Connect(SCBE) server.
+   # IP or FQDN of Spectrum Connect(previously known as SCBE) server.
    SCBE-MANAGEMENT-IP: SCBE_MANAGEMENT_IP_VALUE
 
    # Communication port of Spectrum Connect server. Optional parameter with default value set at 8440.

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity-configmap.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity-configmap.yml
@@ -8,13 +8,13 @@ metadata:
 data:
    # The keys below are used by ubiquity deployment
    # -----------------------------------------------
-   # IP or FQDN of SCBE server.
+   # IP or FQDN of Spectrum Connect(SCBE) server.
    SCBE-MANAGEMENT-IP: SCBE_MANAGEMENT_IP_VALUE
 
-   # Communication port of SCBE server. Optional parameter with default value set at 8440.
+   # Communication port of Spectrum Connect server. Optional parameter with default value set at 8440.
    SCBE-MANAGEMENT-PORT: "SCBE_MANAGEMENT_PORT_VALUE"
 
-   # Default SCBE storage service to be used, if not specified by the plugin.
+   # Default Spectrum Connect storage service to be used, if not specified by the plugin.
    SCBE-DEFAULT-SERVICE: SCBE_DEFAULT_SERVICE_VALUE
 
    # The size for a new volume if not specified by the user when creating a new volume. Optional parameter with default value set at 1GB.

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_installer.conf
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_installer.conf
@@ -37,7 +37,7 @@ DEFAULT_FSTYPE_VALUE=ext4
 DEFAULT_VOLUME_SIZE_VALUE=1
 
 # Ubiquity database PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
-# For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 12 chars.
+# For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
 IBM_UBIQUITY_DB_PV_NAME_VALUE=ibm-ubiquity-db
 
 # Parameter in ubiquity-configmap.yml that impact on "ubiquity-k8s-flex" daemonset

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_installer.conf
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_installer.conf
@@ -17,7 +17,7 @@ UBIQUITY_K8S_FLEX_IMAGE=ibmcom/ibm-storage-flex-volume-for-kubernetes:1.1.0
 
 # Parameters in ubiquity-configmap.yml that impact on ubiquity deployment
 #-----------------------------------------------------------------
-# IP or FQDN of Spectrum Connect(SCBE) server.
+# IP or FQDN of Spectrum Connect(previously known as SCBE) server.
 SCBE_MANAGEMENT_IP_VALUE=VALUE
 
 # Communication port of Spectrum Connect server.
@@ -36,8 +36,8 @@ DEFAULT_FSTYPE_VALUE=ext4
 # The default volume size (in GB) if not specified by the user when creating a new volume.
 DEFAULT_VOLUME_SIZE_VALUE=1
 
-# Ubiquity DB PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
-# For DS8000 Family, use "ibmdb" instead. Make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 12 chars.
+# Ubiquity database PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
+# For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 12 chars.
 IBM_UBIQUITY_DB_PV_NAME_VALUE=ibm-ubiquity-db
 
 # Parameter in ubiquity-configmap.yml that impact on "ubiquity-k8s-flex" daemonset

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_installer.conf
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_installer.conf
@@ -10,20 +10,20 @@
 # ----------------------------------------------------
 
 # The Docker images of IBM Storage Enabler for Containers.
-UBIQUITY_IMAGE=ibmcom/ibm-storage-enabler-for-containers:1.0.0
-UBIQUITY_DB_IMAGE=ibmcom/ibm-storage-enabler-for-containers-db:1.0.0
-UBIQUITY_K8S_PROVISIONER_IMAGE=ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes:1.0.0
-UBIQUITY_K8S_FLEX_IMAGE=ibmcom/ibm-storage-flex-volume-for-kubernetes:1.0.0
+UBIQUITY_IMAGE=ibmcom/ibm-storage-enabler-for-containers:1.1.0
+UBIQUITY_DB_IMAGE=ibmcom/ibm-storage-enabler-for-containers-db:1.1.0
+UBIQUITY_K8S_PROVISIONER_IMAGE=ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes:1.1.0
+UBIQUITY_K8S_FLEX_IMAGE=ibmcom/ibm-storage-flex-volume-for-kubernetes:1.1.0
 
 # Parameters in ubiquity-configmap.yml that impact on ubiquity deployment
 #-----------------------------------------------------------------
-# IP or FQDN of SCBE server.
+# IP or FQDN of Spectrum Connect(SCBE) server.
 SCBE_MANAGEMENT_IP_VALUE=VALUE
 
-# Communication port of SCBE server.
+# Communication port of Spectrum Connect server.
 SCBE_MANAGEMENT_PORT_VALUE=8440
 
-# Default SCBE storage service to be used, if not specified by the storage class.
+# Default Spectrum Connect storage service to be used, if not specified by the storage class.
 SCBE_DEFAULT_SERVICE_VALUE=VALUE
 
 # A prefix for any new volume created on the storage system.
@@ -36,7 +36,8 @@ DEFAULT_FSTYPE_VALUE=ext4
 # The default volume size (in GB) if not specified by the user when creating a new volume.
 DEFAULT_VOLUME_SIZE_VALUE=1
 
-# Ubiquity db pv name, For SVC/XIV, use default value. For DS8k, please set a short name, e.g: ibmdb, because DS8k has a limitation for 16 chars volume name
+# Ubiquity DB PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
+# For DS8000 Family, use "ibmdb" instead. Make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 12 chars.
 IBM_UBIQUITY_DB_PV_NAME_VALUE=ibm-ubiquity-db
 
 # Parameter in ubiquity-configmap.yml that impact on "ubiquity-k8s-flex" daemonset
@@ -56,7 +57,7 @@ SSL_MODE_VALUE=VALUE
 
 # Parameters in scbe-credentials-secret.yml that impact ubiquity and ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset
 #-----------------------------------------------------------------
-# Username and password defined for IBM Storage Enabler for Containers interface in SCBE.
+# Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
 SCBE_USERNAME_VALUE=VALUE
 SCBE_PASSWORD_VALUE=VALUE
 
@@ -74,7 +75,7 @@ UBIQUITY_DB_PASSWORD_VALUE=ubiquity
 # Storage Class name
 STORAGE_CLASS_NAME_VALUE=VALUE
 
-# Storage Class profile parameter should point to the SCBE storage service name
+# Storage Class profile parameter should point to the Spectrum Connect storage service name
 STORAGE_CLASS_PROFILE_VALUE=VALUE
 
 # Storage Class file-system type, Allowed values: ext4 or xfs.

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-deployment.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-deployment.yml
@@ -19,8 +19,8 @@ spec:
         - containerPort: 9999
           name: ubiquity-port
         env:
-          ### SCBE connectivity parameters:
-          #################################
+          ### Spectrum Connect(SCBE) connectivity parameters:
+          #############################################
           - name: SCBE_USERNAME
             valueFrom:
               secretKeyRef:
@@ -53,7 +53,7 @@ spec:
 
 
 
-          ### Ubiquity SCBE backend parameters:
+          ### Ubiquity Spectrum Connect(SCBE) backend parameters:
           #####################################
           - name: SCBE_DEFAULT_SERVICE
             valueFrom:
@@ -99,7 +99,7 @@ spec:
             value: "9999"
           - name: LOG_PATH          # Ubiquity log file directory
             value: "/tmp"
-          - name: DEFAULT_BACKEND   # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Control Base Edition) as its backend.
+          - name: DEFAULT_BACKEND   # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
             value: "scbe"
 
 

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-deployment.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-deployment.yml
@@ -19,7 +19,7 @@ spec:
         - containerPort: 9999
           name: ubiquity-port
         env:
-          ### Spectrum Connect(SCBE) connectivity parameters:
+          ### Spectrum Connect(previously known as SCBE) connectivity parameters:
           #############################################
           - name: SCBE_USERNAME
             valueFrom:
@@ -53,7 +53,7 @@ spec:
 
 
 
-          ### Ubiquity Spectrum Connect(SCBE) backend parameters:
+          ### Ubiquity Spectrum Connect(previously known as SCBE) backend parameters:
           #####################################
           - name: SCBE_DEFAULT_SERVICE
             valueFrom:
@@ -99,7 +99,7 @@ spec:
             value: "9999"
           - name: LOG_PATH          # Ubiquity log file directory
             value: "/tmp"
-          - name: DEFAULT_BACKEND   # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
+          - name: DEFAULT_BACKEND   # "IBM Storage Enabler for Containers" supports "scbe" (Spectrum Connect) as its backend.
             value: "scbe"
 
 

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
@@ -29,7 +29,7 @@ spec:
           - name: UBIQUITY_PORT     # Ubiquity port, should point to the ubiquity service port
             value: "9999"
 
-          - name: UBIQUITY_BACKEND         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Control Base Edition) as its backend.
+          - name: UBIQUITY_BACKEND         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
             value: "scbe"
 
           - name: LOG_LEVEL       # debug / info / error

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-provisioner-deployment.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-provisioner-deployment.yml
@@ -26,7 +26,7 @@ spec:
             value: "1"
           - name: LOG_PATH         # provisioner log file directory
             value: "/tmp"
-          - name: BACKENDS         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Control Base Edition) as its backend.
+          - name: BACKENDS         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
             value: "scbe"
 
           - name: LOG_LEVEL       # debug / info / error


### PR DESCRIPTION
1. Set the new version 1.1.0 as default in the ubiquity_installer.conf, so the installer will take the new images tag 1.1.0 from DockerHub.
2. SCBE rebrand to Spectrum Connect in the installer
3. Fix ds8k test in the ubiquity_installer.conf


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/174)
<!-- Reviewable:end -->
