### PR TITLE
Fix/Flex mount idempotent improvements - wrong branch

### DIFF
--- a/cmd/flex/main/cli.go
+++ b/cmd/flex/main/cli.go
@@ -423,7 +423,7 @@ func (m *MountCommand) Execute(args []string) error {
 
 	mountRequest := k8sresources.FlexVolumeMountRequest{
 		MountPath:   targetMountDir,
-		MountDevice: volumeName,
+		MountDevice: volumeName, // The PV name
 		Opts:        mountOpts,
 		Version:     version,
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -397,6 +397,7 @@ func (c *Controller) doMount(mountRequest k8sresources.FlexVolumeMountRequest) (
 
 	getVolumeRequest := resources.GetVolumeRequest{Name: name}
 	volume, err := c.Client.GetVolume(getVolumeRequest)
+	// TODO idempotent, should fail if vol not exist in ubiquity
 	mounter, err := c.getMounterForBackend(volume.Backend)
 	if err != nil {
 		err = fmt.Errorf("Error determining mounter for volume: %s", err.Error())
@@ -619,7 +620,7 @@ func (c *Controller) doDetach(detachRequest k8sresources.FlexVolumeDetachRequest
 		}
 	}
 
-
+	// TODO idempotent, don't trigger Detach if host is empty (even after getHostAttached)
 	ubDetachRequest := resources.DetachRequest{Name: detachRequest.Name, Host: host}
 	err := c.Client.Detach(ubDetachRequest)
 	if err != nil {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -164,9 +164,11 @@ var _ = Describe("Controller", func() {
 			Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(1))
 		})
 
-		/*
+
 		It("should fail if mounter.Mount failed", func() {
 			// TODO need to mock the mounter in getMounterForBackend
+			errstr := "TODO set error in mounter"
+
 			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "scbe", Mountpoint:"fake"}, nil)
 			byt := []byte(`{"Wwn":"fake"}`)
 			var dat map[string]interface{}
@@ -175,15 +177,15 @@ var _ = Describe("Controller", func() {
 			}
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 
-			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: "/pod/pvnamedir", MountDevice: "pv1", Opts: map[string]string{}}
+			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: "/pod/pvnamedir", MountDevice: "pv1", Opts: map[string]string{"Wwn":"fake"}}
 			mountResponse := controller.Mount(mountRequest)
-			Expect(mountResponse.Message).To(Equal(ctl.MissingWwnMountRequestErrorStr))
+			Expect(mountResponse.Message).To(Equal(errstr))
 			Expect(mountResponse.Status).To(Equal("Failure"))
 			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
 			Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(1))
 		})
 		// TODO continue to add more unit tests
-		*/
+
 
 
 	})

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 )
 
+// TODO need to remove this error, since its moved to ubiquity it self
 type NoMounterForVolumeError struct {
 	mounter string
 }

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -41,3 +41,32 @@ func (e *FailRemovePVorigDirError) Error() string {
 	return fmt.Sprintf(FailRemovePVorigDirErrorStr + ". dir=[%s], err=[%#v]", e.dir, e.err)
 }
 
+const WrongSlinkErrorStr = "Idempotent - The existing slink point to a wrong mountpoint."
+type wrongSlinkError struct {
+	slink string
+	wrongPointTo string
+	expectedPointTo string
+}
+
+func (e *wrongSlinkError) Error() string {
+	return fmt.Sprintf(WrongSlinkErrorStr + " slink=[%s] expected-mountpoint=[%s], wrong-mountpoint=[%s]", e.slink, e.expectedPointTo, e.wrongPointTo)
+}
+
+const SupportK8sVesion = "Support only k8s version >= 1.6."
+type k8sVersionNotSupported struct {
+	version string
+}
+
+func (e *k8sVersionNotSupported) Error() string {
+	return fmt.Sprintf(SupportK8sVesion + " Version [%s] is not supported.", e.version)
+}
+
+const K8sPVDirectoryIsNotDirNorSlinkErrorStr = "k8s PV directory, k8s-mountpoint, is not a directory nor slink."
+type k8sPVDirectoryIsNotDirNorSlinkError struct {
+	slink string
+}
+
+func (e *k8sPVDirectoryIsNotDirNorSlinkError) Error() string {
+	return fmt.Sprintf(K8sPVDirectoryIsNotDirNorSlinkErrorStr + " slink=[%s]", e.slink)
+}
+

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -27,3 +27,5 @@ type NoMounterForVolumeError struct {
 func (e *NoMounterForVolumeError) Error() string {
 	return fmt.Sprintf("Mounter not found for backend: %s", e.mounter)
 }
+
+const MissingWwnMountRequestErrorStr = "volume related to scbe backend must have mountRequest.Opts[Wwn] not found (expect to have wwn for scbe backend volume type)"

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"fmt"
+)
+
+type NoMounterForVolumeError struct {
+	mounter string
+}
+
+func (e *NoMounterForVolumeError) Error() string {
+	return fmt.Sprintf("Mounter not found for backend: %s", e.mounter)
+}

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -30,3 +30,14 @@ func (e *NoMounterForVolumeError) Error() string {
 }
 
 const MissingWwnMountRequestErrorStr = "volume related to scbe backend must have mountRequest.Opts[Wwn] not found (expect to have wwn for scbe backend volume type)"
+
+const FailRemovePVorigDirErrorStr = "Failed removing existing volume directory"
+type FailRemovePVorigDirError struct {
+	err string
+	dir error
+}
+
+func (e *FailRemovePVorigDirError) Error() string {
+	return fmt.Sprintf(FailRemovePVorigDirErrorStr + ". dir=[%s], err=[%#v]", e.dir, e.err)
+}
+

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,10 +9,12 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
+  version: fix/idempotent_issues_in_umount
   subpackages:
   - remote
   - resources
   - utils
+  - fakes
 - package: k8s.io/apimachinery
   version: release-1.8
   subpackages:

--- a/volume/provision.go
+++ b/volume/provision.go
@@ -172,6 +172,10 @@ func (p *flexProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 // Delete removes the directory that was created by Provision backing the given
 // PV.
 func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
+	msg := fmt.Sprintf("Delete volume name [%s]", volume.Name)
+	p.logger.Printf("ENTER : " + msg)
+	defer p.logger.Printf("EXIT : " + msg)
+
 	if volume.Name == "" {
 		return fmt.Errorf("volume name cannot be empty %#v", volume)
 	}
@@ -196,6 +200,10 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 }
 
 func (p *flexProvisioner) createVolume(options controller.VolumeOptions, capacity int64) (map[string]string, error) {
+	msg := fmt.Sprintf("Create volume name [%s]", options.PVName)
+	p.logger.Printf("ENTER : " + msg)
+	defer p.logger.Printf("EXIT : " + msg)
+
 	ubiquityParams := make(map[string]interface{})
 	if capacity != 0 {
 		ubiquityParams["quota"] = fmt.Sprintf("%dM", capacity)    // SSc backend expect quota option


### PR DESCRIPTION
The main goal is to make the mount flow (when creating a POD) to be idempotent as much as possible, and tolerant even if it fail and triggered by k8s.

**Improve mount flow idempotent aspects:**
1.If the <pod-directory>/<pvc> is already slink and it points to the right place (/ubiquity/WWN) then continue instead of failing.
2. If the slink (<pod-directory>/<pvc>) already point to wrong location, mount should fail.
3. If the <pod-directory>/<pvc> is not exist, the flex mount should create create the slink instead of failing
4. Should fail nicely if the PV does NOT exist in the ubiquity-DB.

**In addition, some refactoring:**
1. Break down the controller.Mount() to smaller and readable functions.
2. Develop 100% unit test coverage on the controller.Mount()!
3. Change controller.Mount() to use ubiquity.utils executor interface instead of directly call to os module (Allow to add more unit testing).
4. getMounterForBackend logic moved to ubiquity repo in remote.mounter and built interface for using in the controller.Mount(). This enables to add more unit testing.
5. Add place holders for more idempotent improvements.
6. Fail to mount\umount if comes from k8s 1.5 or lower. Support only k8s v1.6+ (since we support only 1.6+ there is no need to keep the code for v1.5).
7. Add error file for all the formal errors in the controller.Mount.
8. Add missing logging on provisioner create and delete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/176)
<!-- Reviewable:end -->
