### PR TITLE
 #177 : Improve error message for mount idempotent step.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -551,7 +551,7 @@ func (c *Controller) doAfterMount(mountRequest k8sresources.FlexVolumeMountReque
 				"failed")
 		}
 	} else {
-		return c.logger.ErrorRet(&k8sPVDirectoryIsNotDirNorSlinkError{k8sPVDirectoryPath}, "failed")
+		return c.logger.ErrorRet(&k8sPVDirectoryIsNotDirNorSlinkError{k8sPVDirectoryPath, fileInfo}, "failed")
 	}
 
 	c.logger.Debug("Volume mounted successfully", logs.Args{{"mountedPath", mountedPath}})

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"os"
 )
 
 // TODO need to remove this error, since its moved to ubiquity it self
@@ -67,9 +68,12 @@ func (e *k8sVersionNotSupported) Error() string {
 const K8sPVDirectoryIsNotDirNorSlinkErrorStr = "k8s PV directory, k8s-mountpoint, is not a directory nor slink."
 
 type k8sPVDirectoryIsNotDirNorSlinkError struct {
-	slink string
+	slink    string
+	fileInfo os.FileInfo
 }
 
 func (e *k8sPVDirectoryIsNotDirNorSlinkError) Error() string {
-	return fmt.Sprintf(K8sPVDirectoryIsNotDirNorSlinkErrorStr+" slink=[%s]", e.slink)
+	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
+	return fmt.Sprintf(K8sPVDirectoryIsNotDirNorSlinkErrorStr+" slink=[%s], fileInfo=[%#v]",
+		e.slink, e.fileInfo)
 }


### PR DESCRIPTION
Improve error message for a use case in the Flex mount idempotent flow.
So if flex triggered with mount but with mountpoint argument that is not a directory nor slink - then in this case the error message should also contain the fileInfo struct and not only the file path. So it will be easier to troubleshoot what was the file mode in such case. 

This fix derived from @ranhrl code review on PR #177. (internal ticket UB-1113)
