### PR TITLE
Fix/idempotent umount for slink not exist and PV not exist

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -310,8 +310,8 @@ func (c *Controller) checkSlinkBeforeUmount(k8sPVDirectoryPath string, realMount
 	if err != nil {
 		if c.exec.IsNotExist(err) {
 			// The k8s PV directory not exist (its a rare case and indicate on idempotent flow)
-			c.logger.Info("PV directory(k8s-mountpoint) is not exist.", logs.Args{{"k8s-mountpoint", k8sPVDirectoryPath}, {"should-point-to-mountpoint", realMountedPath}}) // TODO change it to warning
-			return false, nil                                                                                                                                               // Idempotent flow
+			c.logger.Info("PV directory(k8s-mountpoint) does not exist.", logs.Args{{"k8s-mountpoint", k8sPVDirectoryPath}, {"should-point-to-mountpoint", realMountedPath}}) // TODO change it to warning
+			return false, nil                                                                                                                                                 // Idempotent flow
 		} else {
 			// Maybe some permissions issue
 			return false, c.logger.ErrorRet(err, "Controller: failed to identify PV directory(k8s-mountpoint)", logs.Args{{"k8s-mountpoint", k8sPVDirectoryPath}})
@@ -670,6 +670,7 @@ func (c *Controller) doAfterDetach(detachRequest k8sresources.FlexVolumeDetachRe
 func (c *Controller) doUnmountSsc(unmountRequest k8sresources.FlexVolumeUnmountRequest, realMountPoint string) error {
 	defer c.logger.Trace(logs.DEBUG)()
 	// TODO : double check why for SScale the function trigger detach instead of umount? in addition its bad practice to get all vols.
+	//        Consider to delete this function since there is no need for special flow for UnMount for SSc.
 	listVolumeRequest := resources.ListVolumesRequest{}
 	volumes, err := c.Client.ListVolumes(listVolumeRequest)
 	if err != nil {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -490,6 +490,226 @@ var _ = Describe("Controller", func() {
 		})
 
 	})
+	Context(".Unmount", func() {
+		It("should fail in GetVolume returns error that is not about volume not found in DB (Unmount)", func() {
+			fakeClient.GetVolumeReturns(resources.Volume{}, fmt.Errorf("just error"))
+			unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/k8s-dir-pod/pv1"}
+
+			mountResponse := controller.Unmount(unmountRequest)
+
+			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+			Expect(mountResponse.Message).To(MatchRegexp(".*just error"))
+			Expect(mountResponse.Status).To(Equal(ctl.FlexFailureStr))
+		})
+		It("should return success if try to unmount PV that is not exist, idempotent issue (Unmount)", func() {
+			fakeClient.GetVolumeReturns(resources.Volume{}, &resources.VolumeNotFoundError{VolName: "pv1"})
+			unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/k8s-dir-pod/pv1"}
+
+			mountResponse := controller.Unmount(unmountRequest)
+
+			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+			Expect(mountResponse.Message).To(MatchRegexp(".*" + resources.VolumeNotFoundErrorMsg))
+			Expect(mountResponse.Status).To(Equal(ctl.FlexSuccessStr))
+		})
+		It("should fail if cannot get mounter for the PV (doMount, GetMounterPerBackend)", func() {
+			errstr := "ERROR backend"
+			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "XXX", Mountpoint: "fake"}, nil)
+			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, fmt.Errorf(errstr))
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
+			unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/k8s-dir-pod/pv1"}
+
+			response := controller.Unmount(unmountRequest)
+
+			Expect(response.Device).To(Equal(""))
+			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+			Expect(fakeMounterFactory.GetMounterPerBackendCallCount()).To(Equal(1))
+			Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(0))
+			Expect(response.Message).To(MatchRegexp(errstr))
+			Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+		})
+		It("should fail to prepareUbiquityMountRequest if GetVolumeConfig failed (doMount)", func() {
+			errstr := "fakeError"
+			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "aaaa", Mountpoint: "fake"}, nil)
+			byt := []byte(`{"":""}`)
+			var dat map[string]interface{}
+			if err := json.Unmarshal(byt, &dat); err != nil {
+				panic(err)
+			}
+			fakeClient.GetVolumeConfigReturns(dat, fmt.Errorf(errstr))
+			unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+			response := controller.Unmount(unmountRequest)
+
+			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+			Expect(fakeMounterFactory.GetMounterPerBackendCallCount()).To(Equal(1))
+			Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(1))
+			Expect(fakeMounter.UnmountCallCount()).To(Equal(0))
+			Expect(response.Message).To(MatchRegexp(errstr))
+			Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+		})
+		It("should fail to doUnmount because volume has unknown backend type", func() {
+			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "aaaa", Mountpoint: "fake"}, nil)
+			byt := []byte(`{"":""}`)
+			var dat map[string]interface{}
+			if err := json.Unmarshal(byt, &dat); err != nil {
+				panic(err)
+			}
+			fakeClient.GetVolumeConfigReturns(dat, nil)
+			unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+			response := controller.Unmount(unmountRequest)
+
+			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+			Expect(fakeMounterFactory.GetMounterPerBackendCallCount()).To(Equal(1))
+			Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(1))
+			Expect(fakeMounter.UnmountCallCount()).To(Equal(0))
+			Expect(response.Message).To(MatchRegexp(ctl.PvBackendNotSupportedErrorStr))
+			Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+		})
+		Context(".Unmount checkSlinkBeforeUmount", func() {
+			var (
+				errstrObj error
+				errstr    string
+				wwn       string
+			)
+			BeforeEach(func() {
+				errstr = "fakerror"
+				errstrObj = fmt.Errorf(errstr)
+				fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: resources.SCBE, Mountpoint: "fake"}, nil)
+				wwn = "fake"
+				byt := []byte(`{"Wwn":"fake"}`) // TODO should use the wwn var inside
+
+				var dat map[string]interface{}
+				if err := json.Unmarshal(byt, &dat); err != nil {
+					panic(err)
+				}
+				fakeClient.GetVolumeConfigReturns(dat, nil)
+			})
+			AfterEach(func() {
+				Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+				Expect(fakeMounterFactory.GetMounterPerBackendCallCount()).To(Equal(1))
+				Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(1))
+				Expect(fakeMounter.UnmountCallCount()).To(Equal(0))
+				Expect(fakeExec.LstatCallCount()).To(Equal(1))
+			})
+
+			// Start with all the failures in this function
+			It("should fail because slink lstat error diff from not exist", func() {
+				fakeExec.LstatReturns(nil, errstrObj)
+				fakeExec.IsNotExistReturns(false)
+				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+				response := controller.Unmount(unmountRequest)
+
+				Expect(fakeExec.IsNotExistCallCount()).To(Equal(1))
+				Expect(response.Message).To(MatchRegexp(errstr))
+				Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+			})
+			It("should fail because its an real slink but cannot eval it", func() {
+				fakeExec.LstatReturns(nil, nil)
+				fakeExec.IsSlinkReturns(true)
+				fakeExec.EvalSymlinksReturns("", errstrObj)
+
+				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+				response := controller.Unmount(unmountRequest)
+
+				Expect(fakeExec.IsSlinkCallCount()).To(Equal(1))
+				Expect(fakeExec.EvalSymlinksCallCount()).To(Equal(1))
+				Expect(response.Message).To(MatchRegexp(errstr))
+				Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+			})
+			It("should fail because its an real slink but cannot eval it", func() {
+				fakeExec.LstatReturns(nil, nil)
+				fakeExec.IsSlinkReturns(true)
+				fakeExec.EvalSymlinksReturns("/fake/evalOfSlink", nil)
+
+				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+				response := controller.Unmount(unmountRequest)
+
+				Expect(fakeExec.IsSlinkCallCount()).To(Equal(1))
+				Expect(fakeExec.EvalSymlinksCallCount()).To(Equal(1))
+				Expect(response.Message).To(MatchRegexp(ctl.WrongSlinkErrorStr))
+				Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+			})
+			It("should fail because slink exist but its not slink", func() {
+				fakeExec.LstatReturns(nil, nil)
+				fakeExec.IsSlinkReturns(false)
+
+				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+				response := controller.Unmount(unmountRequest)
+
+				Expect(fakeExec.IsSlinkCallCount()).To(Equal(1))
+				Expect(fakeExec.EvalSymlinksCallCount()).To(Equal(0))
+				Expect(response.Message).To(MatchRegexp(ctl.K8sPVDirectoryIsNotSlinkErrorStr))
+				Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+			})
+
+		})
+		Context(".Unmount checkSlinkBeforeUmount succeed with slink exist", func() {
+			var (
+				errstrObj error
+				errstr    string
+				wwn       string
+			)
+			BeforeEach(func() {
+				errstr = "fakerror"
+				errstrObj = fmt.Errorf(errstr)
+				fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: resources.SCBE, Mountpoint: "fake"}, nil)
+				wwn = "fake"
+				byt := []byte(`{"Wwn":"fake"}`) // TODO should use the wwn var inside
+
+				var dat map[string]interface{}
+				if err := json.Unmarshal(byt, &dat); err != nil {
+					panic(err)
+				}
+				fakeClient.GetVolumeConfigReturns(dat, nil)
+				fakeExec.LstatReturns(nil, nil)
+				fakeExec.IsSlinkReturns(true)
+			})
+			AfterEach(func() {
+				Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+				Expect(fakeMounterFactory.GetMounterPerBackendCallCount()).To(Equal(1))
+				Expect(fakeClient.GetVolumeConfigCallCount()).To(Equal(1))
+				Expect(fakeExec.LstatCallCount()).To(Equal(1))
+				Expect(fakeExec.IsSlinkCallCount()).To(Equal(1))
+				Expect(fakeExec.EvalSymlinksCallCount()).To(Equal(1))
+				Expect(fakeMounter.UnmountCallCount()).To(Equal(1))
+			})
+			It("should fail unmount because mounter.Unmount failed", func() {
+				fakeExec.EvalSymlinksReturns("/ubiquity/"+wwn, nil)
+				fakeMounter.UnmountReturns(errstrObj)
+				fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
+				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
+
+				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+				response := controller.Unmount(unmountRequest)
+
+				Expect(response.Message).To(MatchRegexp(errstr))
+				Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+			})
+			It("should fail unmount because the removal of slink failed (reminder in this stage the slink exist so it fail due to a real issue of the rm)", func() {
+				fakeExec.EvalSymlinksReturns("/ubiquity/"+wwn, nil)
+				fakeExec.RemoveReturns(errstrObj)
+
+				fakeMounter.UnmountReturns(nil)
+				fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
+				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
+				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
+
+				response := controller.Unmount(unmountRequest)
+
+				Expect(response.Message).To(MatchRegexp(errstr))
+				Expect(response.Status).To(Equal(ctl.FlexFailureStr))
+			})
+			//TODO continue from here!!!!!!!!!!!! to add UT for slink not exist at all. and then continue the flow for after mounter.Unmount
+
+		})
+
+	})
 
 	/*
 		Context(".Mount", func() {

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -100,7 +100,6 @@ type PvBackendNotSupportedError struct {
 }
 
 func (e *PvBackendNotSupportedError) Error() string {
-	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
 	return fmt.Sprintf(PvBackendNotSupportedErrorStr+" backend=[%s]", e.Backend)
 }
 
@@ -111,6 +110,5 @@ type BackendNotImplementedGetRealMountpointError struct {
 }
 
 func (e *BackendNotImplementedGetRealMountpointError) Error() string {
-	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
 	return fmt.Sprintf(BackendNotImplementedGetRealMountpointErrorStr+" backend=[%s]", e.Backend)
 }

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -80,7 +80,7 @@ func (e *k8sPVDirectoryIsNotDirNorSlinkError) Error() string {
 
 const IdempotentUnmountSkipOnVolumeNotExistWarnigMsg = "Warning: Unmount operation requested to work on not exist volume. Assume its idempotent issue - so skip Unmount."
 
-const k8sPVDirectoryIsNotSlinkErrorStr = "k8s PV directory, k8s-mountpoint, is not slink."
+const K8sPVDirectoryIsNotSlinkErrorStr = "k8s PV directory, k8s-mountpoint, is not slink."
 
 type k8sPVDirectoryIsNotSlinkError struct {
 	slink    string
@@ -89,6 +89,28 @@ type k8sPVDirectoryIsNotSlinkError struct {
 
 func (e *k8sPVDirectoryIsNotSlinkError) Error() string {
 	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
-	return fmt.Sprintf(k8sPVDirectoryIsNotSlinkErrorStr+" slink=[%s], fileInfo=[%#v]",
+	return fmt.Sprintf(K8sPVDirectoryIsNotSlinkErrorStr+" slink=[%s], fileInfo=[%#v]",
 		e.slink, e.fileInfo)
+}
+
+const PvBackendNotSupportedErrorStr = "Backend type not supported."
+
+type PvBackendNotSupportedError struct {
+	Backend string
+}
+
+func (e *PvBackendNotSupportedError) Error() string {
+	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
+	return fmt.Sprintf(PvBackendNotSupportedErrorStr+" backend=[%s]", e.Backend)
+}
+
+const BackendNotImplementedGetRealMountpointErrorStr = "Backend do not support getting the real mountpoint from PV"
+
+type BackendNotImplementedGetRealMountpointError struct {
+	Backend string
+}
+
+func (e *BackendNotImplementedGetRealMountpointError) Error() string {
+	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
+	return fmt.Sprintf(BackendNotImplementedGetRealMountpointErrorStr+" backend=[%s]", e.Backend)
 }

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -77,3 +77,18 @@ func (e *k8sPVDirectoryIsNotDirNorSlinkError) Error() string {
 	return fmt.Sprintf(K8sPVDirectoryIsNotDirNorSlinkErrorStr+" slink=[%s], fileInfo=[%#v]",
 		e.slink, e.fileInfo)
 }
+
+const IdempotentUnmountSkipOnVolumeNotExistWarnigMsg = "Warning: Unmount operation requested to work on not exist volume. Assume its idempotent issue - so skip Unmount."
+
+const k8sPVDirectoryIsNotSlinkErrorStr = "k8s PV directory, k8s-mountpoint, is not slink."
+
+type k8sPVDirectoryIsNotSlinkError struct {
+	slink    string
+	fileInfo os.FileInfo
+}
+
+func (e *k8sPVDirectoryIsNotSlinkError) Error() string {
+	// The error string contains also the fileInfo for debug purpose, in order to identify for example what is the actual FileInfo.Mode().
+	return fmt.Sprintf(k8sPVDirectoryIsNotSlinkErrorStr+" slink=[%s], fileInfo=[%#v]",
+		e.slink, e.fileInfo)
+}

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: dev
+  version: fix/idempotent_umount_improvments
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: fix/idempotent_umount_improvments
+  version: dev
   subpackages:
   - remote
   - resources


### PR DESCRIPTION
This PR is to fix some idempotent issues:
1. **fix idempotent 1: if PV not exist** in ubiqutiy DB then finish unmount with success, assuming the volume is no longer exist or mapped.
(Coding aspects: Flex identify the PV not exist in DB by using generic error comes from https://github.com/IBM/ubiquity/pull/216)
2. **fix idempotent 2: if slink (/k8s-pod-dir/PV) not exist** during unmount (delete Pod) then skip
 umount operation(since its was already unmounted) and go to detach stage of the unmount (no need to run umount nor delete the slink). 
 (Coding aspects : Added checkSlinkBeforeUmount() to identify the idempotent state and other abnormal slink states, like if the slink is a different type or some error to identify it.)
3. fix idempotent 3 if slink (/k8s-pod-dir/PV) **point to wrong mountpoint**  or the moutpoint given is not slink then raise error.

**In addition some refactoring** in the flex controller.Unmount():
1. **Identify backend type** by GetVolume instead of hardcoded check by the mountpath.  (coding : getRealMountpointForPvByBackend func)
2. **Agnostic flow for SCBE and Ssc backends** (dropped doUnmountSsc and doUnmountScbe, instead do the same flow for both)
3. **Reuse code** failureFlexVolumeResponse() instead to build it each time.
This PR related to internal ticket UB-1012
4. Adding full unit tests for this PR (there was none on Unmount func).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/193)
<!-- Reviewable:end -->
