### PR TITLE
Fix/ub 1087 isattach succeed if vol does not exist

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -761,7 +761,7 @@ func (c *Controller) doIsAttached(isAttachedRequest k8sresources.FlexVolumeIsAtt
 	attachTo, err := c.getHostAttached(volName, isAttachedRequest.Context)
 	if err != nil {
 		c.logger.Info("###########")
-		c.logger.Info(fmt.Sprintf("err: %s type %s", err, reflect.TypeOf(err)))
+		c.logger.Info(fmt.Sprintf("err: %s type %s ;;; error.Error : %s", err, reflect.TypeOf(err), err.Error()))
 		matched, _ := regexp.MatchString("volume .* not found", err.Error())
 		if matched {
 			c.logger.Info("MATCHED!")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -199,20 +199,12 @@ func (c *Controller) IsAttached(isAttachedRequest k8sresources.FlexVolumeIsAttac
 
 	isAttached, err := c.doIsAttached(isAttachedRequest)
 	if err != nil {
-		c.logger.Info(fmt.Sprintf("err: %s type %s", err, reflect.TypeOf(err)))
-		matched, _ := regexp.MatchString("volume .* not found", err.Error())
-		if matched{
-			response = k8sresources.FlexVolumeResponse{
-				Status:   "Success",
-				Attached: false,
-			}
-		} else{
-			msg := fmt.Sprintf("Failed to check IsAttached volume [%s], Error: %#v", isAttachedRequest.Name, err)
-			response = k8sresources.FlexVolumeResponse{
+		msg := fmt.Sprintf("Failed to check IsAttached volume [%s], Error: %#v", isAttachedRequest.Name, err)
+		response = k8sresources.FlexVolumeResponse{
 				Status:  "Failure",
 				Message: msg,
-			}
 		}
+		
 	} else {
 		response = k8sresources.FlexVolumeResponse{
 			Status:   "Success",
@@ -768,6 +760,13 @@ func (c *Controller) doIsAttached(isAttachedRequest k8sresources.FlexVolumeIsAtt
 
 	attachTo, err := c.getHostAttached(volName, isAttachedRequest.Context)
 	if err != nil {
+		c.logger.Info("###########")
+		c.logger.Info(fmt.Sprintf("err: %s type %s", err, reflect.TypeOf(err)))
+		matched, _ := regexp.MatchString("volume .* not found", err.Error())
+		if matched {
+			c.logger.Info("MATCHED!")
+			return false, nil
+		}
 		return false, c.logger.ErrorRet(err, "getHostAttached failed")
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -32,6 +32,8 @@ import (
 	"github.com/nightlyone/lockfile"
 	"path/filepath"
 	"time"
+	"regexp"
+	"reflect"
 )
 
 const FlexSuccessStr = "Success"
@@ -197,10 +199,19 @@ func (c *Controller) IsAttached(isAttachedRequest k8sresources.FlexVolumeIsAttac
 
 	isAttached, err := c.doIsAttached(isAttachedRequest)
 	if err != nil {
-		msg := fmt.Sprintf("Failed to check IsAttached volume [%s], Error: %#v", isAttachedRequest.Name, err)
-		response = k8sresources.FlexVolumeResponse{
-			Status:  "Failure",
-			Message: msg,
+		c.logger.Info(fmt.Sprintf("err: %s type %s", err, reflect.TypeOf(err)))
+		matched, _ := regexp.MatchString("volume .* not found", err.Error())
+		if matched{
+			response = k8sresources.FlexVolumeResponse{
+				Status:   "Success",
+				Attached: false,
+			}
+		} else{
+			msg := fmt.Sprintf("Failed to check IsAttached volume [%s], Error: %#v", isAttachedRequest.Name, err)
+			response = k8sresources.FlexVolumeResponse{
+				Status:  "Failure",
+				Message: msg,
+			}
 		}
 	} else {
 		response = k8sresources.FlexVolumeResponse{


### PR DESCRIPTION
This PR will make sure that isAttached API will not fail with an error if volume does not exist (causing the master-flex to go into a loop of calling isAttached) .
if isAttached encounters a "vol <volume> does not exist" error it will return false and not raise an exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/198)
<!-- Reviewable:end -->
