### PR TITLE
Fix tolerations setting in flex daemonset to support also ICP v2.1.0.2+ 

### DIFF
--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-k8s-flex-daemonset.yml
@@ -17,8 +17,7 @@ spec:
       tolerations:   # Create flex Pods also on master nodes (even if there are NoScheduled nodes)
       # Some k8s versions use dedicated key for toleration of the master and some use node-role.kubernetes.io/master key.
       - key: dedicated
-        operator: Equal
-        value: master
+        operator: Exists
         effect: NoSchedule
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
Installing Ubiqutiy in ICP 2.1.0.2+ is failing because the daemonset tolerations setting is not working well on ICP v 2.1.0.2+. 
the ICP master nodes (BTW on vanila k8s the current tolerations as ok).  
Matthew Levan found that the current tolerations setting in the flex daemonset are not working on ICP 2.1.0.2+ and its not installing flex on the master nodes at all (only on the worker nodes which is not enough).

Here is the current daemonset toleration setting:
```
      tolerations:  
      - key: dedicated
        operator: Equal
        value: master
        effect: NoSchedule

```
In order to make it works also on ICP 2.1.0.2+ (and also vanilla k8s) here is fixed setting:
```
      tolerations:  
      - key: dedicated
        operator: Exists
        effect: NoSchedule

```

Note: internal ticket UB-1009

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/203)
<!-- Reviewable:end -->
