### PR TITLE
Fix/ub 1349 can attach two pods to one pvc

### DIFF
--- a/cmd/flex/main/cli.go
+++ b/cmd/flex/main/cli.go
@@ -124,7 +124,7 @@ func (a *AttachCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 
 	if err != nil {
 		panic(fmt.Sprintf("backend %s not found", config))
@@ -170,7 +170,7 @@ func (wfa *WaitForAttachCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 	opts := make(map[string]string)
 	err = json.Unmarshal([]byte(args[1]), &opts)
 	if err != nil {
@@ -210,7 +210,7 @@ func (d *IsAttachedCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 	opts := make(map[string]string)
 	err = json.Unmarshal([]byte(args[0]), &opts)
 	if err != nil {
@@ -261,7 +261,7 @@ func (d *DetachCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 
 	if err != nil {
 		panic("backend not found")
@@ -297,7 +297,7 @@ func (d *MountDeviceCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 	opts := make(map[string]string)
 	err = json.Unmarshal([]byte(args[2]), &opts)
 	if err != nil {
@@ -337,7 +337,7 @@ func (d *UnmountDeviceCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 
 	unmountDeviceRequest := k8sresources.FlexVolumeUnmountDeviceRequest{Name: args[0], Context: requestContext}
 	response := controller.UnmountDevice(unmountDeviceRequest)
@@ -423,7 +423,7 @@ func (m *MountCommand) Execute(args []string) error {
 	defer k8sutils.InitFlexLogger(config)()
 	extraParams := make(map[string]interface{})
 	extraParams["pv"] = volumeName
-	controller, err := createController(config, extraParams)
+	controller, err := createController(config)
 
 	if err != nil {
 		panic("backend not found")
@@ -461,7 +461,7 @@ func (u *UnmountCommand) Execute(args []string) error {
 	}
 
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 
 	if err != nil {
 		panic("backend not found")
@@ -490,7 +490,7 @@ func (i *TestUbiquityCommand) Execute(args []string) error {
 	}
 
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config, nil)
+	controller, err := createController(config)
 	if err != nil {
 		response := k8sresources.FlexVolumeResponse{
 			Status:  "Failure",
@@ -572,9 +572,9 @@ func main() {
 	}
 }
 
-func createController(config resources.UbiquityPluginConfig, extraParams map[string]interface{}) (*controller.Controller, error) {
+func createController(config resources.UbiquityPluginConfig) (*controller.Controller, error) {
 	logger := utils.SetupOldLogger(k8sresources.UbiquityFlexLogFileName)
-	controller, err := controller.NewController(logger, config, extraParams)
+	controller, err := controller.NewController(logger, config)
 	return controller, err
 }
 

--- a/cmd/flex/main/cli.go
+++ b/cmd/flex/main/cli.go
@@ -124,7 +124,7 @@ func (a *AttachCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 
 	if err != nil {
 		panic(fmt.Sprintf("backend %s not found", config))
@@ -170,7 +170,7 @@ func (wfa *WaitForAttachCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 	opts := make(map[string]string)
 	err = json.Unmarshal([]byte(args[1]), &opts)
 	if err != nil {
@@ -210,7 +210,7 @@ func (d *IsAttachedCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 	opts := make(map[string]string)
 	err = json.Unmarshal([]byte(args[0]), &opts)
 	if err != nil {
@@ -261,7 +261,7 @@ func (d *DetachCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 
 	if err != nil {
 		panic("backend not found")
@@ -297,7 +297,7 @@ func (d *MountDeviceCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 	opts := make(map[string]string)
 	err = json.Unmarshal([]byte(args[2]), &opts)
 	if err != nil {
@@ -337,7 +337,7 @@ func (d *UnmountDeviceCommand) Execute(args []string) error {
 		return printResponse(response)
 	}
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 
 	unmountDeviceRequest := k8sresources.FlexVolumeUnmountDeviceRequest{Name: args[0], Context: requestContext}
 	response := controller.UnmountDevice(unmountDeviceRequest)
@@ -421,7 +421,9 @@ func (m *MountCommand) Execute(args []string) error {
 	}
 
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	extraParams := make(map[string]interface{})
+	extraParams["pv"] = volumeName
+	controller, err := createController(config, extraParams)
 
 	if err != nil {
 		panic("backend not found")
@@ -459,7 +461,7 @@ func (u *UnmountCommand) Execute(args []string) error {
 	}
 
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 
 	if err != nil {
 		panic("backend not found")
@@ -488,7 +490,7 @@ func (i *TestUbiquityCommand) Execute(args []string) error {
 	}
 
 	defer k8sutils.InitFlexLogger(config)()
-	controller, err := createController(config)
+	controller, err := createController(config, nil)
 	if err != nil {
 		response := k8sresources.FlexVolumeResponse{
 			Status:  "Failure",
@@ -570,9 +572,9 @@ func main() {
 	}
 }
 
-func createController(config resources.UbiquityPluginConfig) (*controller.Controller, error) {
+func createController(config resources.UbiquityPluginConfig, extraParams map[string]interface{}) (*controller.Controller, error) {
 	logger := utils.SetupOldLogger(k8sresources.UbiquityFlexLogFileName)
-	controller, err := controller.NewController(logger, config)
+	controller, err := controller.NewController(logger, config, extraParams)
 	return controller, err
 }
 
@@ -598,3 +600,4 @@ func printResponse(f k8sresources.FlexVolumeResponse) error {
 	fmt.Printf("%s", string(responseBytes[:]))
 	return nil
 }
+

--- a/cmd/flex/main/cli.go
+++ b/cmd/flex/main/cli.go
@@ -421,8 +421,6 @@ func (m *MountCommand) Execute(args []string) error {
 	}
 
 	defer k8sutils.InitFlexLogger(config)()
-	extraParams := make(map[string]interface{})
-	extraParams["pv"] = volumeName
 	controller, err := createController(config)
 
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -586,7 +586,11 @@ func checkSlinkAlreadyExistsOnMountPoint(mountPoint string, k8sMountPoint string
 	}
 	
 	mountStat, err := executer.Stat(mountPoint)
-	if err != nil{
+	if err != nil {
+		if os.IsNotExist(err){
+			// assuming path to mountPoint does not exist means it was never linked to before
+			return nil
+		}
 		return logger.ErrorRet(err, "Failed to get stat for mount point file.", logs.Args{{"file", mountPoint}})
 	}
 	

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -51,38 +51,30 @@ type Controller struct {
 	mounterPerBackend map[string]resources.Mounter
 	unmountFlock      lockfile.Lockfile
 	mounterFactory    mounter.MounterFactory
+	mountFlock	  *lockfile.Lockfile
 }
 
-//NewController allows to instantiate a controller
-func NewController(logger *log.Logger, config resources.UbiquityPluginConfig) (*Controller, error) {
+func newController(logger *log.Logger, config resources.UbiquityPluginConfig, client resources.StorageClient, exec utils.Executor, mFactory mounter.MounterFactory, extraParams map[string]interface{}) (*Controller, error) {
 	unmountFlock, err := lockfile.New(filepath.Join(os.TempDir(), "ubiquity.unmount.lock"))
 	if err != nil {
 		panic(err)
 	}
 
-	remoteClient, err := remote.NewRemoteClientSecure(logger, config)
-	if err != nil {
-		return nil, err
+	var mountFlock *lockfile.Lockfile
+	mountFlock = nil
+	
+	val, ok := extraParams["pv"]
+	if ok {
+		strVal, ok := val.(string)
+		if ok {
+			lock, err := lockfile.New(filepath.Join(os.TempDir(),strVal ))
+			if err != nil {
+				panic(err)
+			}
+			mountFlock = &lock 
+		}
 	}
-	return &Controller{
-		logger:            logs.GetLogger(),
-		legacyLogger:      logger,
-		Client:            remoteClient,
-		exec:              utils.NewExecutor(),
-		config:            config,
-		mounterPerBackend: make(map[string]resources.Mounter),
-		unmountFlock:      unmountFlock,
-		mounterFactory:    mounter.NewMounterFactory(),
-	}, nil
-}
-
-//NewControllerWithClient is made for unit testing purposes where we can pass a fake client
-func NewControllerWithClient(logger *log.Logger, config resources.UbiquityPluginConfig, client resources.StorageClient, exec utils.Executor, mFactory mounter.MounterFactory) *Controller {
-	unmountFlock, err := lockfile.New(filepath.Join(os.TempDir(), "ubiquity.unmount.lock"))
-	if err != nil {
-		panic(err)
-	}
-
+	
 	return &Controller{
 		logger:            logs.GetLogger(),
 		legacyLogger:      logger,
@@ -92,7 +84,24 @@ func NewControllerWithClient(logger *log.Logger, config resources.UbiquityPlugin
 		mounterPerBackend: make(map[string]resources.Mounter),
 		unmountFlock:      unmountFlock,
 		mounterFactory:    mFactory,
+		mountFlock:	   mountFlock,
+	}, nil
+}
+
+//NewController allows to instantiate a controller
+func NewController(logger *log.Logger, config resources.UbiquityPluginConfig, extraParams map[string]interface{}) (*Controller, error) {
+	remoteClient, err := remote.NewRemoteClientSecure(logger, config)
+	if err != nil {
+		return nil, err
 	}
+	
+	return newController(logger, config, remoteClient, utils.NewExecutor(), mounter.NewMounterFactory(), extraParams)
+}
+
+//NewControllerWithClient is made for unit testing purposes where we can pass a fake client
+func NewControllerWithClient(logger *log.Logger, config resources.UbiquityPluginConfig, client resources.StorageClient, exec utils.Executor, mFactory mounter.MounterFactory, extraParams map[string]interface{}) *Controller {
+	controller, _ :=  newController(logger, config, client, exec, mFactory, extraParams)
+	return controller
 }
 
 //Init method is to initialize the k8sresourcesvolume
@@ -280,6 +289,22 @@ func (c *Controller) Mount(mountRequest k8sresources.FlexVolumeMountRequest) k8s
 	var response k8sresources.FlexVolumeResponse
 	c.logger.Debug("", logs.Args{{"request", mountRequest}})
 
+	if c.mountFlock == nil{
+		err := &MountFlockIsNotInitializedError{}
+		c.logger.Error(err.Error())
+		return c.failureFlexVolumeResponse(err, "")
+	}
+	for {
+		err := c.mountFlock.TryLock()
+		if err == nil {
+			break
+		}
+		c.logger.Debug("mountFlock.TryLock failed", logs.Args{{"error", err}})
+		time.Sleep(time.Duration(500 * time.Millisecond))
+	}
+	c.logger.Debug("Got mountFlock for volume.", logs.Args{{"volume", mountRequest.MountDevice}})
+	defer c.mountFlock.Unlock()
+	
 	// TODO check if volume exist first and what its backend type
 	mountedPath, err := c.doMount(mountRequest)
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -273,7 +273,8 @@ func (c *Controller) Mount(mountRequest k8sresources.FlexVolumeMountRequest) k8s
 	var response k8sresources.FlexVolumeResponse
 	c.logger.Debug("", logs.Args{{"request", mountRequest}})
 	
-	mountFlock, err := lockfile.New(filepath.Join(os.TempDir(), mountRequest.MountDevice ))
+	flockName := fmt.Sprintf("ubiquity.mount.%s.lock", mountRequest.MountDevice)
+	mountFlock, err := lockfile.New(filepath.Join(os.TempDir(), flockName ))
 	if err != nil {
 		panic(err)
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -525,7 +525,7 @@ func (c *Controller) prepareUbiquityMountRequest(mountRequest k8sresources.FlexV
 		return resources.MountRequest{}, c.logger.ErrorRet(err, "failed")
 	}
 	volumeMountpoint := fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, wwn)
-	ubMountRequest := resources.MountRequest{Mountpoint: volumeMountpoint, VolumeConfig: volumeConfig, Context: mountRequest.Context, K8sMountPath: mountRequest.MountPath}
+	ubMountRequest := resources.MountRequest{Mountpoint: volumeMountpoint, VolumeConfig: volumeConfig, Context: mountRequest.Context}
 	return ubMountRequest, nil
 }
 
@@ -643,7 +643,7 @@ func (c *Controller) doMount(mountRequest k8sresources.FlexVolumeMountRequest) (
 		return "", c.logger.ErrorRet(err, "prepareUbiquityMountRequest failed")
 	}
 	
-	err = checkSlinkAlreadyExistsOnMountPoint(ubMountRequest.Mountpoint, ubMountRequest.K8sMountPath, c.logger, c.exec)
+	err = checkSlinkAlreadyExistsOnMountPoint(ubMountRequest.Mountpoint, mountRequest.MountPath, c.logger, c.exec)
 	if err != nil {
 		return "", c.logger.ErrorRet(err, "Failed to check if other links point to mountpoint")
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -521,7 +521,7 @@ func (c *Controller) prepareUbiquityMountRequest(mountRequest k8sresources.FlexV
 		return resources.MountRequest{}, c.logger.ErrorRet(err, "failed")
 	}
 	volumeMountpoint := fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, wwn)
-	ubMountRequest := resources.MountRequest{Mountpoint: volumeMountpoint, VolumeConfig: volumeConfig, Context: mountRequest.Context}
+	ubMountRequest := resources.MountRequest{Mountpoint: volumeMountpoint, VolumeConfig: volumeConfig, Context: mountRequest.Context, K8sMountPath: mountRequest.MountPath}
 	return ubMountRequest, nil
 }
 

--- a/controller/controller_internal_test.go
+++ b/controller/controller_internal_test.go
@@ -1,5 +1,10 @@
 package controller
 
+/**
+	These tests are not in controller_test.go because they have to be inside the package of 
+	the module they are testing so that it will be possible to test not exporeted functions.
+**/
+
 import (
 	"fmt"
 	. "github.com/onsi/ginkgo"
@@ -7,6 +12,8 @@ import (
 	"github.com/IBM/ubiquity/utils/logs"
 	"github.com/IBM/ubiquity/fakes"
 )
+
+
 
 var _ = Describe("controller_internal_tests", func() {
 	Context(".getK8sBaseDir", func() {

--- a/controller/controller_internal_test.go
+++ b/controller/controller_internal_test.go
@@ -89,19 +89,19 @@ var _ = Describe("controller_internal_tests", func() {
 			Expect(err).To(Equal(errstrObj))
 
 		})
-		It("should return error if stat function returns an error", func() {
+		It("should return error if stat function on the mountpoint returns an error", func() {
 			errstrObj := fmt.Errorf("An error ooccured")
 			fakeExecutor.GetGlobFilesReturns([]string{"/tmp/file1"}, nil)
 			fakeExecutor.StatReturns(nil, errstrObj)
 			err:= checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
 			Expect(err).To(Equal(errstrObj))
 		})
-		It("should return error if stat on mountpoint function returns an error", func() {
+		It("should continue if stat on a link returns an error", func() {
 			errstrObj := fmt.Errorf("An error ooccured")
 			fakeExecutor.GetGlobFilesReturns([]string{"/tmp/file1"}, nil)
 			fakeExecutor.StatReturnsOnCall(1, nil, errstrObj)
 			err := checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
-			Expect(err).To(Equal(errstrObj))
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/controller/controller_internal_test.go
+++ b/controller/controller_internal_test.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/IBM/ubiquity/utils/logs"
+	"github.com/IBM/ubiquity/fakes"
+)
+
+var _ = Describe("controller_internal_tests", func() {
+	Context(".getK8sBaseDir", func() {
+		It("should succeed if path is correct", func() {
+			res, err := getK8sPodsBaseDir("/var/lib/kubelet/pods/1f94f1d9-8f36-11e8-b227-005056a4d4cb/volumes/ibm~ubiquity-k8s-flex/pvc-123")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal("/var/lib/kubelet/pods"))
+		})
+		It("should succeed if path is correct and not default", func() {
+			res, err := getK8sPodsBaseDir("/tmp/kubelet/pods/1f94f1d9-8f36-11e8-b227-005056a4d4cb/volumes/ibm~ubiquity-k8s-flex/pvc-123")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal("/tmp/kubelet/pods"))
+		})
+		It("should fail if path is not of correct structure", func() {
+			k8smountpoint := "/tmp/kubelet/soemthing/1f94f1d9-8f36-11e8-b227-005056a4d4cb/volumes/ibm~ubiquity-k8s-flex/pvc-123"
+			res, err := getK8sPodsBaseDir(k8smountpoint)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(&WrongK8sDirectoryPathError{k8smountpoint}))
+			Expect(res).To(Equal(""))
+		})
+		It("should fail if path is not of correct structure", func() {
+			k8smountpoint := "/tmp/kubelet/soemthing/pods/1f94f1d9-8f36-11e8-b227-005056a4d4cb/volumes/ibm~ubiquity-k8s-flex"
+			res, err := getK8sPodsBaseDir(k8smountpoint)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(&WrongK8sDirectoryPathError{k8smountpoint}))
+			Expect(res).To(Equal(""))
+		})
+	})
+	Context(".checkSlinkAlreadyExistsOnMountPoint", func() {
+		var (
+			fakeExecutor *fakes.FakeExecutor
+			mountPoint string
+		)
+		BeforeEach(func() {
+			fakeExecutor = new(fakes.FakeExecutor)
+			mountPoint = "/tmp/kubelet/pods/1f94f1d9-8f36-11e8-b227-005056a4d4cb/volumes/ibm~ubiquity-k8s-flex/pvc-123"
+		})
+		It("should return no error if it is the first volume", func() {
+			fakeExecutor.GetGlobFilesReturns([]string{}, nil)
+			err := checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(BeNil())
+		})
+		It("should return no error if there are no other links", func() {
+			fakeExecutor.GetGlobFilesReturns([]string{"/tmp/file1", "/tmp/file2"}, nil)
+			fakeExecutor.IsSameFileReturns(false)
+			err:= checkSlinkAlreadyExistsOnMountPoint("mountPoint",mountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(BeNil())
+		})
+		It("should return an error if this mountpoint already has links", func() {
+			file := "/tmp/file1"
+			fakeExecutor.GetGlobFilesReturns([]string{file}, nil)
+			fakeExecutor.IsSameFileReturns(true)
+			err:= checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).ToNot(BeNil())
+			Expect(err).To(Equal(&PVIsAlreadyUsedByAnotherPod{"mountPoint", []string{file}}))
+		})
+		It("should return no errors if this mountpoint has only one links and it is the current pvc", func() {
+			file := mountPoint
+			fakeExecutor.GetGlobFilesReturns([]string{file}, nil)
+			fakeExecutor.IsSameFileReturns(true)
+			err := checkSlinkAlreadyExistsOnMountPoint("mountPoint", file, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(BeNil())
+		})
+		It("should return error if getk8sbaseDir returns an error", func() {
+			k8sMountPoint := "/tmp/kubelet/something"
+			err := checkSlinkAlreadyExistsOnMountPoint("mountPoint", k8sMountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(Equal(&WrongK8sDirectoryPathError{k8sMountPoint}))
+		})
+		It("should return error if glob  returns an error", func() {
+			errstrObj := fmt.Errorf("An error ooccured")
+			fakeExecutor.GetGlobFilesReturns(nil, errstrObj)
+			err := checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(Equal(errstrObj))
+
+		})
+		It("should return error if stat function returns an error", func() {
+			errstrObj := fmt.Errorf("An error ooccured")
+			fakeExecutor.GetGlobFilesReturns([]string{"/tmp/file1"}, nil)
+			fakeExecutor.StatReturns(nil, errstrObj)
+			err:= checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(Equal(errstrObj))
+		})
+		It("should return error if stat on mountpoint function returns an error", func() {
+			errstrObj := fmt.Errorf("An error ooccured")
+			fakeExecutor.GetGlobFilesReturns([]string{"/tmp/file1"}, nil)
+			fakeExecutor.StatReturnsOnCall(1, nil, errstrObj)
+			err := checkSlinkAlreadyExistsOnMountPoint("mountPoint", mountPoint, logs.GetLogger(), fakeExecutor)
+			Expect(err).To(Equal(errstrObj))
+		})
+	})
+})
+

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Controller", func() {
 		fakeClient = new(fakes.FakeStorageClient)
 		fakeMounterFactory = new(fakes.FakeMounterFactory)
 		fakeMounter = new(fakes.FakeMounter)
-		controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
+		controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 		byt := []byte(`{"Wwn":"fake"}`)
 		if err := json.Unmarshal(byt, &dat); err != nil {
 			panic(err)
@@ -125,7 +125,7 @@ var _ = Describe("Controller", func() {
 		BeforeEach(func(){
 			extraParams = make(map[string]interface{})
 			extraParams["pv"] = "volume_name"
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 		})
 		It("should fail if k8s version < 1.6 (doMount)", func() {
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: "fake", MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_5}
@@ -151,7 +151,7 @@ var _ = Describe("Controller", func() {
 			errstr := "ERROR backend"
 			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "XXX", Mountpoint: "fake"}, nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, fmt.Errorf(errstr))
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{}}
 
 			mountResponse := controller.Mount(mountRequest)
@@ -214,7 +214,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("fake device", fmt.Errorf(errstr))
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}}
 
 			mountResponse := controller.Mount(mountRequest)
@@ -234,7 +234,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("/ubiquity/wwn1", nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			fakeExec.LstatReturns(nil, errstrObj)
 			fakeExec.IsNotExistReturns(false)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
@@ -259,7 +259,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("/ubiquity/wwn1", nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			fakeExec.LstatReturns(nil, errstrObj)
 			fakeExec.IsNotExistReturns(true)
 			fakeExec.SymlinkReturns(errstrObj)
@@ -286,7 +286,7 @@ var _ = Describe("Controller", func() {
 			mountpoint := "/ubiquity/wwn1"
 			fakeMounter.MountReturns(mountpoint, nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			fakeExec.LstatReturns(nil, errstrObj)
 			fakeExec.IsNotExistReturns(true)
 			fakeExec.SymlinkReturns(nil)
@@ -313,7 +313,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("/ubiquity/wwn1", nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(true)
@@ -340,7 +340,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("/ubiquity/wwn1", nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(true)
@@ -367,7 +367,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("/ubiquity/wwn1", nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(true)
@@ -397,7 +397,7 @@ var _ = Describe("Controller", func() {
 			fakeClient.GetVolumeConfigReturns(dat, nil)
 			fakeMounter.MountReturns("/ubiquity/wwn1", nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(false)
@@ -424,7 +424,7 @@ var _ = Describe("Controller", func() {
 
 			fakeMounter.MountReturns(mountPath, nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(false)
@@ -453,7 +453,7 @@ var _ = Describe("Controller", func() {
 
 			fakeMounter.MountReturns(mountPath, nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(false)
@@ -481,7 +481,7 @@ var _ = Describe("Controller", func() {
 
 			fakeMounter.MountReturns(mountPath, nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 			fakeExec.LstatReturns(nil, nil)
 			fakeExec.IsDirReturns(false)
@@ -503,23 +503,13 @@ var _ = Describe("Controller", func() {
 		It("should fail to Mount when there are errors from checking other slinks (idempotent) (doMount)", func() {
 			err :=  fmt.Errorf("an Error has occured")
 			fakeExec.GetGlobFilesReturns(nil, err)
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, extraParams)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 
 			mountResponse := controller.Mount(mountRequest)
 			Expect(mountResponse.Message).To(Equal(err.Error()))
 			Expect(mountResponse.Status).To(Equal(ctl.FlexFailureStr))
 			Expect(fakeExec.GetGlobFilesCallCount()).To(Equal(1))
-		})
-		It("should fail if mount lock is not initialized", func() {
-			err := &ctl.MountFlockIsNotInitializedError{} 
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
-			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
-
-			mountResponse := controller.Mount(mountRequest)
-			Expect(mountResponse.Message).To(Equal(err.Error()))
-			Expect(mountResponse.Status).To(Equal(ctl.FlexFailureStr))
-			Expect(fakeMounter.MountCallCount()).To(Equal(0))
 		})
 	})
 	Context(".Unmount", func() {
@@ -547,7 +537,7 @@ var _ = Describe("Controller", func() {
 			errstr := "ERROR backend"
 			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "XXX", Mountpoint: "fake"}, nil)
 			fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, fmt.Errorf(errstr))
-			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
+			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 			unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/k8s-dir-pod/pv1"}
 
 			response := controller.Unmount(unmountRequest)
@@ -714,7 +704,7 @@ var _ = Describe("Controller", func() {
 				fakeExec.EvalSymlinksReturns("/ubiquity/"+wwn, nil)
 				fakeMounter.UnmountReturns(errstrObj)
 				fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
+				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 
 				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
 
@@ -729,7 +719,7 @@ var _ = Describe("Controller", func() {
 
 				fakeMounter.UnmountReturns(nil)
 				fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
+				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 				unmountRequest := k8sresources.FlexVolumeUnmountRequest{MountPath: "/pod/pv1"}
 
 				response := controller.Unmount(unmountRequest)
@@ -770,7 +760,7 @@ var _ = Describe("Controller", func() {
 				fakeExec.EvalSymlinksReturns("/ubiquity/"+wwn, nil)
 				fakeMounter.UnmountReturns(nil)
 				fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
+				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 				fakeExec.IsSlinkReturns(true)
 				fakeExec.LstatReturns(nil, nil)
 
@@ -788,7 +778,7 @@ var _ = Describe("Controller", func() {
 				fakeExec.EvalSymlinksReturns("/ubiquity/"+wwn, nil)
 				fakeMounter.UnmountReturns(nil)
 				fakeMounterFactory.GetMounterPerBackendReturns(fakeMounter, nil)
-				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory, nil)
+				controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
 				fakeExec.IsSlinkReturns(true)
 				fakeExec.LstatReturns(nil, fmt.Errorf("error because file not exist")) // simulate idempotent with no slink exist
 				fakeExec.IsNotExistReturns(true)                                       // simulate idempotent with no slink exist

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -27,6 +27,7 @@ import (
 	k8sresources "github.com/IBM/ubiquity-k8s/resources"
 	"github.com/IBM/ubiquity/fakes"
 	"github.com/IBM/ubiquity/resources"
+	"github.com/IBM/ubiquity/utils/utils_fakes"
 )
 
 var _ = Describe("Controller", func() {
@@ -34,14 +35,14 @@ var _ = Describe("Controller", func() {
 	var (
 		fakeClient         *fakes.FakeStorageClient
 		controller         *ctl.Controller
-		fakeExec           *fakes.FakeExecutor
+		fakeExec           *utils_fakes.FakeExecutor
 		fakeMounterFactory *fakes.FakeMounterFactory
 		fakeMounter        *fakes.FakeMounter
 		ubiquityConfig     resources.UbiquityPluginConfig
 		dat                map[string]interface{}
 	)
 	BeforeEach(func() {
-		fakeExec = new(fakes.FakeExecutor)
+		fakeExec = new(utils_fakes.FakeExecutor)
 		ubiquityConfig = resources.UbiquityPluginConfig{}
 		fakeClient = new(fakes.FakeStorageClient)
 		fakeMounterFactory = new(fakes.FakeMounterFactory)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -491,7 +491,7 @@ var _ = Describe("Controller", func() {
 			Expect(mountResponse.Message).To(MatchRegexp(ctl.K8sPVDirectoryIsNotDirNorSlinkErrorStr))
 			Expect(mountResponse.Status).To(Equal(ctl.FlexFailureStr))
 		})
-		FIt("should fail to Mount when there are errors from checking other slinks (idempotent) (doMount)", func() {
+		It("should fail to Mount when there are errors from checking other slinks (idempotent) (doMount)", func() {
 			err :=  fmt.Errorf("an Error has occured")
 			fakeExec.GetGlobFilesReturns(nil, err)
 			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
@@ -500,6 +500,7 @@ var _ = Describe("Controller", func() {
 			mountResponse := controller.Mount(mountRequest)
 			Expect(mountResponse.Message).To(Equal(err.Error()))
 			Expect(mountResponse.Status).To(Equal(ctl.FlexFailureStr))
+			Expect(fakeExec.GetGlobFilesCallCount()).To(Equal(1))
 		})
 
 	})

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -112,3 +112,24 @@ type BackendNotImplementedGetRealMountpointError struct {
 func (e *BackendNotImplementedGetRealMountpointError) Error() string {
 	return fmt.Sprintf(BackendNotImplementedGetRealMountpointErrorStr+" backend=[%s]", e.Backend)
 }
+
+const PVIsAlreadyUsedByAnotherPodMessage = "PV is already in use by another pod and has an existing slink to mountpoint."
+
+type PVIsAlreadyUsedByAnotherPod struct {
+	mountpoint string
+	slink      []string
+}
+
+func (e *PVIsAlreadyUsedByAnotherPod) Error() string {
+	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + " mountpoint=[%s], slinks=[%s]", e.mountpoint, e.slink)
+}
+
+var WrongK8sDirectoryPathErrorMessage = fmt.Sprintf("Expected to find \"%s\" directory in k8s mount path.",K8sPodsDirecotryName)
+
+type WrongK8sDirectoryPathError struct {
+	k8smountdir string
+}
+
+func (e *WrongK8sDirectoryPathError) Error() string {
+	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + "k8smountdir=[%s]", e.k8smountdir)
+}

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -124,7 +124,7 @@ func (e *PVIsAlreadyUsedByAnotherPod) Error() string {
 	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + " mountpoint=[%s], slinks=[%s]", e.mountpoint, e.slink)
 }
 
-var WrongK8sDirectoryPathErrorMessage = fmt.Sprintf("Expected to find \"%s\" directory in k8s mount path.",K8sPodsDirecotryName)
+var WrongK8sDirectoryPathErrorMessage = fmt.Sprintf("Expected to find [%s] directory in k8s mount path.",K8sPodsDirecotryName)
 
 type WrongK8sDirectoryPathError struct {
 	k8smountdir string

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -134,12 +134,3 @@ func (e *WrongK8sDirectoryPathError) Error() string {
 	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + "k8smountdir=[%s]", e.k8smountdir)
 }
 
-var MountFlockIsNotInitializedErrorMessage = fmt.Sprintf("Mount lock is not initialized.")
-
-type MountFlockIsNotInitializedError struct {
-}
-
-func (e *MountFlockIsNotInitializedError) Error() string {
-	return fmt.Sprintf(MountFlockIsNotInitializedErrorMessage)
-}
-

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -133,3 +133,13 @@ type WrongK8sDirectoryPathError struct {
 func (e *WrongK8sDirectoryPathError) Error() string {
 	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + "k8smountdir=[%s]", e.k8smountdir)
 }
+
+var MountFlockIsNotInitializedErrorMessage = fmt.Sprintf("Mount lock is not initialized.")
+
+type MountFlockIsNotInitializedError struct {
+}
+
+func (e *MountFlockIsNotInitializedError) Error() string {
+	return fmt.Sprintf(MountFlockIsNotInitializedErrorMessage)
+}
+

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: fb29982e56dd27790363fa720db6a67cb4380e3e
+  version: c10c565fb5731c84e9b2a7920f0f6a62478d988e
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 05e9661ce829f9947ae5f28d4f8c9b3b08514988
+  version: b590dfd556e29ba4c19c8198a2d5dd852d646c2f
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
   - sortkeys
   - ptypes
 - package: github.com/golang/glog
-- package: github.com/golang/groupcach
+- package: github.com/golang/groupcache
   subpackages:
   - lru
 - package: github.com/google/gofuzz

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 2658568b4dfff217bd232a3b96a6ea5360971cbf
+  version: f9e824946f22b43b0c0d4b160080c3bac94fe716
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: aed6a3029502cc33106d8be271926a36fd5b3f23
+  version: 0d8fe88b0e3b69cdd982f334ab3c9ea8a4904149
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 2b225eaef53cbcaeeaaabf4e7e9cb757b995d0f5
+  version: fdb2dbba3db6faa7f6311fb05db8a09c79474515
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,7 +13,6 @@ import:
   - proto
   - sortkeys
   - ptypes
-- package: github.com/golang/glog
 - package: github.com/golang/groupcache
   subpackages:
   - lru

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
   - sortkeys
   - ptypes
 - package: github.com/golang/glog
-- package: github.com/golang/groupcache
+- package: github.com/golang/groupcach
   subpackages:
   - lru
 - package: github.com/google/gofuzz
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: c10c565fb5731c84e9b2a7920f0f6a62478d988e
+  version: 05e9661ce829f9947ae5f28d4f8c9b3b08514988
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: b590dfd556e29ba4c19c8198a2d5dd852d646c2f
+  version: 91d1631c10f984a7073c6d2d2d2dd8f8d5224dc7
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,6 +13,7 @@ import:
   - proto
   - sortkeys
   - ptypes
+- package: github.com/golang/glog
 - package: github.com/golang/groupcache
   subpackages:
   - lru

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 91d1631c10f984a7073c6d2d2d2dd8f8d5224dc7
+  version: 2b225eaef53cbcaeeaaabf4e7e9cb757b995d0f5
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: a54d6ec92caede791cdc081c23c4ed00a6de5042
+  version: aed6a3029502cc33106d8be271926a36fd5b3f23
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 88e559f9a7e74f62dbad620b4474a33eac8f00ac
+  version: a54d6ec92caede791cdc081c23c4ed00a6de5042
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: fdb2dbba3db6faa7f6311fb05db8a09c79474515
+  version: 88e559f9a7e74f62dbad620b4474a33eac8f00ac
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -89,7 +89,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 490b484a3484811cdb85691b53013ddeede9b24a
+  version: 4a100552b47f4a7af093d74f408bf922b2ae9fca
   subpackages:
   - remote
   - resources


### PR DESCRIPTION
This PR is to not allow attachement of 2 pods to one PVC.
currently this is allowed due to a fix of another idempotent issue.
we are checking if a PVC is already attached to another pod using the slinks - in the mount process we check if the /ubiquity/volume is already linked to a pod that is not the current pod - if so then we will fail the mount process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/204)
<!-- Reviewable:end -->
