### PR TITLE
UB-1491: Add log message for flex detach

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -886,14 +886,23 @@ func (c *Controller) doDetach(detachRequest k8sresources.FlexVolumeDetachRequest
 	if host == "" {
 		// only when triggered during unmount
 		var err error
-		host, err = c.getHostAttached(detachRequest.Name, detachRequest.Context)
+		
+		// TODO: using getvolumeconfig outside the getHostAttached because we need the WWN for automation testing. 
+		// if this ever changes need to remove this and go back to using regular getHostAttached.
+		getVolumeConfigRequest := resources.GetVolumeConfigRequest{Name: detachRequest.Name, Context: detachRequest.Context}
+		volumeConfig, err := c.Client.GetVolumeConfig(getVolumeConfigRequest)
 		if err != nil {
-			return c.logger.ErrorRet(err, "getHostAttached failed")
+			return c.logger.ErrorRet(err, "getVolumeConfig failed.", logs.Args{{"vol", detachRequest.Name}})
+		}
+		
+		host, err = c.getHostAttachUsingConfig(volumeConfig)
+		if err != nil {
+			return c.logger.ErrorRet(err, "getHostAttached failed.")
 		}
 		
 		if host == "" {
 			// this means that the host is not attached to anything so no reason to call detach
-			c.logger.Warning(fmt.Sprintf("Vol: %s is not attahced to any host. so no detach action is called.", detachRequest.Name))
+			c.logger.Warning(fmt.Sprintf("Idempotent issue encoutered - vol is not attached to any host. so no detach action is called"), logs.Args{{"vol wwn", volumeConfig["Wwn"]}})
 			return nil
 		}
 	}
@@ -926,6 +935,16 @@ func (c *Controller) doIsAttached(isAttachedRequest k8sresources.FlexVolumeIsAtt
 	return isAttached, nil
 }
 
+func (c *Controller) getHostAttachUsingConfig(volumeConfig map[string]interface{}) (string, error){
+	attachTo, ok := volumeConfig[resources.ScbeKeyVolAttachToHost].(string)
+	if !ok {
+		return "", c.logger.ErrorRet(fmt.Errorf("GetVolumeConfig missing info"), "GetVolumeConfig missing info", logs.Args{{"arg", resources.ScbeKeyVolAttachToHost}})
+	}
+	c.logger.Debug("", logs.Args{{"volumeConfig", volumeConfig}, {"attachTo", attachTo}})
+
+	return attachTo, nil
+}
+
 func (c *Controller) getHostAttached(volName string, requestContext resources.RequestContext) (string, error) {
 	defer c.logger.Trace(logs.DEBUG)()
 
@@ -934,14 +953,8 @@ func (c *Controller) getHostAttached(volName string, requestContext resources.Re
 	if err != nil {
 		return "", c.logger.ErrorRet(err, "Client.GetVolumeConfig failed")
 	}
-
-	attachTo, ok := volumeConfig[resources.ScbeKeyVolAttachToHost].(string)
-	if !ok {
-		return "", c.logger.ErrorRet(err, "GetVolumeConfig missing info", logs.Args{{"arg", resources.ScbeKeyVolAttachToHost}})
-	}
-	c.logger.Debug("", logs.Args{{"volumeConfig", volumeConfig}, {"attachTo", attachTo}})
-
-	return attachTo, nil
+	
+	return c.getHostAttachUsingConfig(volumeConfig)
 }
 
 func getVolumeForMountpoint(mountpoint string, volumes []resources.Volume) (resources.Volume, error) {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -887,8 +887,8 @@ func (c *Controller) doDetach(detachRequest k8sresources.FlexVolumeDetachRequest
 		// only when triggered during unmount
 		var err error
 		
-		// TODO: using getvolumeconfig outside the getHostAttached because we need the WWN for automation testing. 
-		// if this ever changes need to remove this and go back to using regular getHostAttached.
+		// TODO: if the automation will stop using loggin authenticatin and the WWN here is no longer needed we can
+		// we can go back to using regulat getHostAttached and remove getHostAttachUsingConfig.
 		getVolumeConfigRequest := resources.GetVolumeConfigRequest{Name: detachRequest.Name, Context: detachRequest.Context}
 		volumeConfig, err := c.Client.GetVolumeConfig(getVolumeConfigRequest)
 		if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -938,7 +938,7 @@ func (c *Controller) doIsAttached(isAttachedRequest k8sresources.FlexVolumeIsAtt
 func (c *Controller) getHostAttachUsingConfig(volumeConfig map[string]interface{}) (string, error){
 	attachTo, ok := volumeConfig[resources.ScbeKeyVolAttachToHost].(string)
 	if !ok {
-		return "", c.logger.ErrorRet(fmt.Errorf("GetVolumeConfig missing info"), "GetVolumeConfig missing info", logs.Args{{"arg", resources.ScbeKeyVolAttachToHost}})
+		return "", c.logger.ErrorRet(fmt.Errorf("GetVolumeConfig is missing info"), "GetVolumeConfig missing info.", logs.Args{{"arg", resources.ScbeKeyVolAttachToHost}})
 	}
 	c.logger.Debug("", logs.Args{{"volumeConfig", volumeConfig}, {"attachTo", attachTo}})
 


### PR DESCRIPTION
This PR is needed for the automated testing of the idempotent issues. (yes its known that this is not good, but that is the current state of the automation hopefully this could be avoided and changed in the future)
the automation needs there to be a WWN in the warning message so in order to not make multiple calls to ubiquity server there was small refactor done .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/208)
<!-- Reviewable:end -->
