### PR TITLE
UB-1503: epic1 : Fix ubiqutiy flex Mount API to fetch the right Scale PV mountpoint 

### DIFF
--- a/cmd/provisioner/main/main.go
+++ b/cmd/provisioner/main/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
+	"flag"
 )
 
 var (
@@ -38,6 +39,11 @@ var (
 )
 
 func main() {
+
+	/* this is fixing an existing issue with glog in kuberenetes in version 1.9
+		if we ever move to a newer code version this can be removed.
+	*/  
+	flag.CommandLine.Parse([]string{})
 
 	ubiquityConfig, err := k8sutils.LoadConfig()
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -383,7 +383,7 @@ func (c *Controller) getRealMountpointForPvByBackend(volumeBackend string, volum
 	if volumeBackend == resources.SCBE {
 		return fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, volumeConfig["Wwn"].(string)), nil
 	} else if volumeBackend == resources.SpectrumScale {
-		return "", &BackendNotImplementedGetRealMountpointError{Backend: volumeBackend}
+                return volumeConfig["mountpoint"].(string), nil
 	} else {
 		return "", &PvBackendNotSupportedError{Backend: volumeBackend}
 	}
@@ -996,6 +996,7 @@ func getHost(hostRequest string) string {
 	}
 	// Only in k8s 1.5 this os.Hostname will happened,
 	// because in k8s 1.5 the flex CLI doesn't get the host to attach with. TODO consider to refactor to remove support for 1.5
+	// Spectrum Scale uses this method for 2.0 release.
 	hostname, err := os.Hostname()
 	if err != nil {
 		return ""

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -706,11 +706,9 @@ func (c *Controller) getK8sPVDirectoryByBackend(mountedPath string, k8sPVDirecto
 	*/
 
 	// TODO route between backend by using the volume backend instead of using /ubiquity hardcoded in the mountpoint
-	ubiquityMountPrefix := fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, "")
 	var lnPath string
 	lnPath = k8sPVDirectory
 	// TODO: Keeping this function for scale-nfs support in future.
-	}
 	return lnPath
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -530,16 +530,16 @@ func (c *Controller) getMountpointForVolume(mountRequest k8sresources.FlexVolume
 		volumeMountPoint, ok = volumeConfig["mountpoint"].(string)
 		if !ok {
 			return "", c.logger.ErrorRet(&MissingMountPointVolumeError{VolumeName: mountRequest.MountDevice}, "failed")
-		}			
+		}
 	} else if (volumeBackend == resources.SCBE) {
 		wwn, ok := mountRequest.Opts["Wwn"]
 		if !ok {
 			err := fmt.Errorf(MissingWwnMountRequestErrorStr)
 			return "", c.logger.ErrorRet(err, "failed")
 		}
-		volumeMountPoint = fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, wwn) 
+		volumeMountPoint = fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, wwn)
 	} else {
-		return "", c.logger.ErrorRet(&PvBackendNotSupportedError{Backend: volumeBackend}, "failed") 
+		return "", c.logger.ErrorRet(&PvBackendNotSupportedError{Backend: volumeBackend}, "failed")
 	}
 
 	return volumeMountPoint, nil
@@ -580,7 +580,7 @@ func (c *Controller) getMounterByPV(mountRequest k8sresources.FlexVolumeMountReq
 		return nil, "", c.logger.ErrorRet(err, "getMounterForBackend failed")
 	}
 
-	return mounter, volume.Backend,  nil
+	return mounter, volume.Backend, nil
 }
 
 func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
@@ -685,7 +685,7 @@ func (c *Controller) doMount(mountRequest k8sresources.FlexVolumeMountRequest) (
 	if err != nil {
 		return "", c.logger.ErrorRet(err, "prepareUbiquityMountRequest failed")
 	}
-	
+
 	err = checkSlinkAlreadyExistsOnMountPoint(ubMountRequest.Mountpoint, mountRequest.MountPath, c.logger, c.exec)
 	if err != nil {
 		return "", c.logger.ErrorRet(err, "Failed to check if other links point to mountpoint")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -529,7 +529,7 @@ func (c *Controller) getMountpointForVolume(mountRequest k8sresources.FlexVolume
 	if (volumeBackend == resources.SpectrumScale) {
 		volumeMountPoint, ok = volumeConfig["mountpoint"].(string)
 		if !ok {
-			return "", c.logger.ErrorRet(&MissingMountPointVolumeError{VolumeName: mountRequest.MountDevice}, "failed")
+			return "", c.logger.ErrorRet(&SpectrumScaleMissingMntPtVolumeError{VolumeName: mountRequest.MountDevice}, "failed")
 		}
 	} else if (volumeBackend == resources.SCBE) {
 		wwn, ok := mountRequest.Opts["Wwn"]

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -972,7 +972,7 @@ func (c *Controller) getHostAttached(volName string, requestContext resources.Re
 	if err != nil {
 		return "", c.logger.ErrorRet(err, "Client.GetVolumeConfig failed")
 	}
-	
+
 	return c.getHostAttachUsingConfig(volumeConfig)
 }
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -708,11 +708,8 @@ func (c *Controller) getK8sPVDirectoryByBackend(mountedPath string, k8sPVDirecto
 	// TODO route between backend by using the volume backend instead of using /ubiquity hardcoded in the mountpoint
 	ubiquityMountPrefix := fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, "")
 	var lnPath string
-	if strings.HasPrefix(mountedPath, ubiquityMountPrefix) {
-		lnPath = k8sPVDirectory
-	} else {
-		lnPath = k8sPVDirectory
-		// Keeping this separate condition for scale-nfs support in future.
+	lnPath = k8sPVDirectory
+	// TODO: Keeping this function for scale-nfs support in future.
 	}
 	return lnPath
 }
@@ -996,7 +993,8 @@ func getHost(hostRequest string) string {
 	}
 	// Only in k8s 1.5 this os.Hostname will happened,
 	// because in k8s 1.5 the flex CLI doesn't get the host to attach with. TODO consider to refactor to remove support for 1.5
-	// Spectrum Scale uses this method for 2.0 release.
+	// Spectrum Scale uses this method to get the hostname of current node for detach and IsAttached functionality as Spectrum Scale volume is not attached to any specific node.
+	// TODO: Remove this dependancy while optimizing the Spectrum Scale detach functionality.
 	hostname, err := os.Hostname()
 	if err != nil {
 		return ""

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -711,7 +711,8 @@ func (c *Controller) getK8sPVDirectoryByBackend(mountedPath string, k8sPVDirecto
 	if strings.HasPrefix(mountedPath, ubiquityMountPrefix) {
 		lnPath = k8sPVDirectory
 	} else {
-		lnPath, _ = path.Split(k8sPVDirectory) // TODO verify why Scale backend use this split?
+		lnPath = k8sPVDirectory
+		// Keeping this separate condition for scale-nfs support in future.
 	}
 	return lnPath
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -133,7 +133,7 @@ func (c *Controller) Attach(attachRequest k8sresources.FlexVolumeAttachRequest) 
 	volume, err :=  c.Client.GetVolume(getVolumeRequest)
 
 	if err != nil {
-		errormsg := fmt.Sprintf("Failed to Volume details [%s]", attachRequest.Name)
+		errormsg := fmt.Sprintf("Failed to get Volume details [%s]", attachRequest.Name)
 		response = c.failureFlexVolumeResponse(err, errormsg)
 		return response
 	}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -504,6 +504,7 @@ var _ = Describe("Controller", func() {
 			err :=  fmt.Errorf("an Error has occured")
 			fakeExec.GetGlobFilesReturns(nil, err)
 			controller = ctl.NewControllerWithClient(testLogger, ubiquityConfig, fakeClient, fakeExec, fakeMounterFactory)
+			fakeClient.GetVolumeReturns(resources.Volume{Name: "pv1", Backend: "scbe", Mountpoint: "fake"}, nil)
 			mountRequest := k8sresources.FlexVolumeMountRequest{MountPath: mountPoint, MountDevice: "pv1", Opts: map[string]string{"Wwn": "fake"}, Version: k8sresources.KubernetesVersion_1_6OrLater}
 
 			mountResponse := controller.Mount(mountRequest)

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -134,13 +134,13 @@ func (e *WrongK8sDirectoryPathError) Error() string {
 	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + "k8smountdir=[%s]", e.k8smountdir)
 }
 
-const MissingMountPointVolumeErrorStr = "MountPoint Missing in Volume Config."
+const SpectrumScaleMissingMntPtVolumeErrorStr = "MountPoint Missing in Volume Config."
 
-type MissingMountPointVolumeError struct {
+type SpectrumScaleMissingMntPtVolumeError struct {
         VolumeName string
 }
 
-func (e *MissingMountPointVolumeError) Error() string {
-        return fmt.Sprintf(MissingMountPointVolumeErrorStr+" volume=[%s]", e.VolumeName)
+func (e *SpectrumScaleMissingMntPtVolumeError) Error() string {
+        return fmt.Sprintf(SpectrumScaleMissingMntPtVolumeErrorStr+" volume=[%s]", e.VolumeName)
 }
 

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -134,3 +134,13 @@ func (e *WrongK8sDirectoryPathError) Error() string {
 	return fmt.Sprintf(PVIsAlreadyUsedByAnotherPodMessage + "k8smountdir=[%s]", e.k8smountdir)
 }
 
+const MissingMountPointVolumeErrorStr = "MountPoint Missing in Volume Config."
+
+type MissingMountPointVolumeError struct {
+        VolumeName string
+}
+
+func (e *MissingMountPointVolumeError) Error() string {
+        return fmt.Sprintf(MissingMountPointVolumeErrorStr+" volume=[%s]", e.VolumeName)
+}
+

--- a/controller/errors.go
+++ b/controller/errors.go
@@ -79,6 +79,8 @@ func (e *k8sPVDirectoryIsNotDirNorSlinkError) Error() string {
 }
 
 const IdempotentUnmountSkipOnVolumeNotExistWarnigMsg = "Unmount operation requested to work on not exist volume. Assume its idempotent issue - so skip Unmount."
+const IdempotentIsAttachedSkipOnVolumeNotExistWarnigMsg = "IsAttached operation requested to work on not exist volume. Assume its idempotent issue - so skip IsAttached."
+const IdempotentDetachSkipOnVolumeNotExistWarnigMsg = "Detach operation requested to work on not exist volume. Assume its idempotent issue - so skip Detach."
 
 const K8sPVDirectoryIsNotSlinkErrorStr = "k8s PV directory, k8s-mountpoint, is not slink."
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -110,7 +110,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: a91d9984ae76f7a15cb18b5e0c318bc8d85a350e
+  version: 19891dbfbc526a5f56e87bcccb6342f638dd8080
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -110,7 +110,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 6cf91681a933db96cfb78c05f3f27c20cba9f8af
+  version: 422904c4c777d359341f22687ab6e3c9b459c470
   subpackages:
   - remote
   - resources

--- a/glide.yaml
+++ b/glide.yaml
@@ -110,7 +110,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 19891dbfbc526a5f56e87bcccb6342f638dd8080
+  version: 6cf91681a933db96cfb78c05f3f27c20cba9f8af
   subpackages:
   - remote
   - resources


### PR DESCRIPTION
This PR is needed  for getting mounpoints based on respective backends during mount operation.
1) For Scale backend Attach/Detach/IsAttached will return 'Not supported'.  For idempotent aspects see below:
   - in Detach if PV not found in DB it return success
   - in IsAttached if PV not found it return false.
   - Attach if PV not found in DB or for other error, it return error.
   - Note: if PV has backend that is not SCBE nor Scale the APIs should return error PvBackendNotSupportedError.

2) Fixing the Mount Flex API to support scale as well:
   For SpectrumScale we get MountPoint from volumeConfig[‘mountpoint’]. For spectrum-scale backend, mountpoint is ways fetched from Scale backend during GetVolumeConfig.  For SCBE we use “Wwn” from mountRequestOptions. 



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/209)
<!-- Reviewable:end -->
