### PR TITLE
Fix/ub 1431 fix glog errors in provisioner

### DIFF
--- a/cmd/provisioner/main/main.go
+++ b/cmd/provisioner/main/main.go
@@ -40,6 +40,9 @@ var (
 
 func main() {
 
+	/* this is fixing an existing issue with glog in kuberenetes in version 1.9
+		if we ever move to a newer code version this can be removed.
+	*/  
 	flag.CommandLine.Parse([]string{})
 
 	ubiquityConfig, err := k8sutils.LoadConfig()

--- a/cmd/provisioner/main/main.go
+++ b/cmd/provisioner/main/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
+	"flag"
 )
 
 var (
@@ -38,6 +39,8 @@ var (
 )
 
 func main() {
+
+	flag.CommandLine.Parse([]string{})
 
 	ubiquityConfig, err := k8sutils.LoadConfig()
 	if err != nil {


### PR DESCRIPTION
currently there are errors filling the provisioner logs that look like this:
`ERROR: logging before flag.Parse: I0716 13:33:58.655590       1 controller.go:1063] volume "ibm-ubiquity-db" deleted from database
ERROR: logging before flag.Parse: I0716 13:34:00.224200       1 controller.go:826] volume "ibm-ubiquity-db" for claim "ubiquity/ibm-
`
they seem to be caused by some change in glog (used by kuberentes)
this small fix removes them from the log.

(fix was taking from : https://github.com/cloudnativelabs/kube-router/pull/60/commits/78a0aeb39793c86a7fcb9688bf63a72a6cbb4f90 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/212)
<!-- Reviewable:end -->
