### PR TITLE
phase1 - Helm Chart

### DIFF
--- a/helm_chart/ibm_storage_enabler_for_containers/.helmignore
+++ b/helm_chart/ibm_storage_enabler_for_containers/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm_chart/ibm_storage_enabler_for_containers/Chart.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for IBM Storage Enabler for Containers
+name: ibm-storage-enalber-for-containers
+version: 2.0.0

--- a/helm_chart/ibm_storage_enabler_for_containers/Chart.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/Chart.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for IBM Storage Enabler for Containers
+name: ibm-storage-enalber-for-containers
+version: 2.0.0

--- a/helm_chart/ibm_storage_enabler_for_containers/Chart.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/Chart.yml
@@ -1,5 +1,0 @@
-apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart for IBM Storage Enabler for Containers
-name: ibm-storage-enalber-for-containers
-version: 2.0.0

--- a/helm_chart/ibm_storage_enabler_for_containers/README.md
+++ b/helm_chart/ibm_storage_enabler_for_containers/README.md
@@ -1,0 +1,4 @@
+Helm Chart for IBM Storage Enabler for Containers
+
+Before installing this Helm Chart you must preform the prerequisite mentioned in IBM Storage Enabler for Containers user guide.
+https://www-945.ibm.com/support/fixcentral/swg/selectFixes?parent=Software%2Bdefined%2Bstorage&product=ibm/StorageSoftware/IBM+Spectrum+Connect&release=All&platform=Linux&function=all

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
@@ -5,23 +5,6 @@ metadata:
   labels:
     product: ibm-storage-enabler-for-containers
 data:
+  # TODO later on we will replace this with service account and RBAC, but for phase1 its good enough
   config: |
-    apiVersion: v1
-    clusters:
-    - cluster:
-        insecure-skip-tls-verify: true
-        server: {{ .Values.genericConfig.k8sApiServerAccess.server }}
-      name: cluster.local
-    contexts:
-    - context:
-        cluster: cluster.local
-        namespace: default
-        user: admin
-      name: cluster.local-context
-    current-context: cluster.local-context
-    kind: Config
-    preferences: {}
-    users:
-    - name: admin
-      user:
-        token: {{ .Values.genericConfig.k8sApiServerAccess.token }}
+{{ .Files.Get "config" | indent 4 }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-config
+  labels:
+    product: ibm-storage-enabler-for-containers
+data:
+  config: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        insecure-skip-tls-verify: true
+        server: {{ .Values.genericConfig.k8sApiServerAccess.server }}
+      name: cluster.local
+    contexts:
+    - context:
+        cluster: cluster.local
+        namespace: default
+        user: admin
+      name: cluster.local-context
+    current-context: cluster.local-context
+    kind: Config
+    preferences: {}
+    users:
+    - name: admin
+      user:
+        token: {{ .Values.genericConfig.k8sApiServerAccess.token }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 data:
    # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
-   username: {{ .Values.spectrumConnect.connectionInfo.username | quote  }}
+   username: {{ .Values.spectrumConnect.connectionInfo.username | b64enc | quote  }}
 
    # Base64-encoded password defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
    password: {{ .Values.spectrumConnect.connectionInfo.password | b64enc | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scbe-credentials
+  labels:
+    product: ibm-storage-enabler-for-containers
+# Spectrum Connect(previously known as SCBE) credentials needed for ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset.
+type: Opaque
+data:
+   # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
+   username: {{ .Values.spectrumConnect.connectionInfo.username | quote  }}
+
+   # Base64-encoded password defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
+   password: {{ .Values.spectrumConnect.connectionInfo.password | b64enc | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
@@ -1,0 +1,13 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
+  labels:
+    product: ibm-storage-enabler-for-containers
+#  annotations:
+#   storageclass.beta.kubernetes.io/is-default-class: "true"
+provisioner: "ubiquity/flex"
+parameters:
+  profile: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.params.spectrumConnectServiceName  | quote }}
+  fstype: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.params.fsType  | quote }}        # xfs or ext4
+  backend: "scbe"

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
@@ -32,13 +32,13 @@ data:
    # The following keys are used by ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemon-set
    # ----------------------------------------------------------------------------------------------------------------------------
    # Flex log path. Allow to configure it, just make sure the the new path exist on all the minons and update the hostpath in the Flex daemonset
-   FLEX-LOG-DIR: {{ .Values.GenericConfig.logging.flexLogDir | quote  }}
+   FLEX-LOG-DIR: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
 
    # Maxlog size(MB) for rotate
    FLEX-LOG-ROTATE-MAXSIZE: "50"
 
    # Log level. Allowed values: debug, info, error.
-   LOG-LEVEL: {{ .Values.GenericConfig.logging.logLevel  | quote }}
+   LOG-LEVEL: {{ .Values.genericConfig.logging.logLevel  | quote }}
 
    # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
    SSL-MODE: {{ .Values.spectrumConnect.connectionInfo.sslMode | quote }}
@@ -48,7 +48,7 @@ data:
    # --------------------------------------------------------------
    # The IP address of the ubiquity service object. The ubiquity_installer.sh automatically updates this field during the initial installation.
    # The user must update this key manually if the ubiqutiy service object IP was changed.
-   UBIQUITY-IP-ADDRESS: "UBIQUITY_IP_ADDRESS_VALUE"
+   UBIQUITY-IP-ADDRESS: {{ .Values.genericConfig.ubiquityIpAddress | quote }}
 
    # Allowed values: true or false. Set to true if the nodes have FC connectivity.
    SKIP-RESCAN-ISCSI: {{ .Values.spectrumConnect.backendConfig.skipRescanIscsi | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+# IBM Storage Enabler for Containers Kubernetes daemonset and deployments settings.
+  name: ubiquity-configmap
+  labels:
+    product: ibm-storage-enabler-for-containers
+data:
+   # The keys below are used by ubiquity deployment
+   # -----------------------------------------------
+   # IP or FQDN of Spectrum Connect(previously known as SCBE) server.
+   SCBE-MANAGEMENT-IP: {{ .Values.spectrumConnect.connectionInfo.fqdn | quote }}
+
+   # Communication port of Spectrum Connect server. Optional parameter with default value set at 8440.
+   SCBE-MANAGEMENT-PORT: {{ .Values.spectrumConnect.connectionInfo.port | quote }}
+
+   # Default Spectrum Connect storage service to be used, if not specified by the plugin.
+   SCBE-DEFAULT-SERVICE: {{ .Values.spectrumConnect.backendConfig.DefaultStorageService | quote }}
+
+   # The size for a new volume if not specified by the user when creating a new volume. Optional parameter with default value set at 1GB.
+   DEFAULT-VOLUME-SIZE: {{ .Values.spectrumConnect.backendConfig.newVolumeDefaults.size | quote }}
+
+   # A prefix for any new volume created on the storage system. Default value is None.
+   UBIQUITY-INSTANCE-NAME: {{ .Values.spectrumConnect.backendConfig.instanceName | quote }}
+
+   # File system type. Optional parameter with two allowed values: ext4 or xfs. Default value is ext4.
+   DEFAULT-FSTYPE: {{ .Values.spectrumConnect.backendConfig.newVolumeDefaults.fsType | quote }}
+
+   # DB pv name.
+   IBM-UBIQUITY-DB-PV-NAME: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}
+
+   # The following keys are used by ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemon-set
+   # ----------------------------------------------------------------------------------------------------------------------------
+   # Flex log path. Allow to configure it, just make sure the the new path exist on all the minons and update the hostpath in the Flex daemonset
+   FLEX-LOG-DIR: {{ .Values.GenericConfig.logging.flexLogDir | quote  }}
+
+   # Maxlog size(MB) for rotate
+   FLEX-LOG-ROTATE-MAXSIZE: "50"
+
+   # Log level. Allowed values: debug, info, error.
+   LOG-LEVEL: {{ .Values.GenericConfig.logging.logLevel  | quote }}
+
+   # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
+   SSL-MODE: {{ .Values.spectrumConnect.connectionInfo.sslMode | quote }}
+
+
+   # The following keys are used by the ubiquity-k8s-flex daemonset
+   # --------------------------------------------------------------
+   # The IP address of the ubiquity service object. The ubiquity_installer.sh automatically updates this field during the initial installation.
+   # The user must update this key manually if the ubiqutiy service object IP was changed.
+   UBIQUITY-IP-ADDRESS: "UBIQUITY_IP_ADDRESS_VALUE"
+
+   # Allowed values: true or false. Set to true if the nodes have FC connectivity.
+   SKIP-RESCAN-ISCSI: {{ .Values.spectrumConnect.backendConfig.skipRescanIscsi | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
@@ -11,10 +11,10 @@ metadata:
 type: Opaque
 data:
    # Base64-encoded username to be set for the ubiquity-db deployment.
-   username: {{ .Values.genericConfig.ubiquityPersistency.ubiquityDbCredentials.username | quote }}
+   username: {{ .Values.genericConfig.ubiquityDbCredentials.username | b64enc | quote }}
 
    # Base64-encoded password to be set for the ubiquity-db deployment.
-   password: {{ .Values.genericConfig.ubiquityPersistency.ubiquityDbCredentials.password | b64enc | quote }}
+   password: {{ .Values.genericConfig.ubiquityDbCredentials.password | b64enc | quote }}
 
    # Base64-encoded database name ("dWJpcXVpdHk=" base64 is "ubiquity") to be created for the ubiquity-db deployment.
    dbname: "dWJpcXVpdHk="

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
@@ -11,10 +11,10 @@ metadata:
 type: Opaque
 data:
    # Base64-encoded username to be set for the ubiquity-db deployment.
-   username: {{ .Values.GenericConfig.ubiquityPersistency.ubiquityDbCredentials.username | quote }}
+   username: {{ .Values.genericConfig.ubiquityPersistency.ubiquityDbCredentials.username | quote }}
 
    # Base64-encoded password to be set for the ubiquity-db deployment.
-   password: {{ .Values.GenericConfig.ubiquityPersistency.ubiquityDbCredentials.password | b64enc | quote }}
+   password: {{ .Values.genericConfig.ubiquityPersistency.ubiquityDbCredentials.password | b64enc | quote }}
 
    # Base64-encoded database name ("dWJpcXVpdHk=" base64 is "ubiquity") to be created for the ubiquity-db deployment.
    dbname: "dWJpcXVpdHk="

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ubiquity-db-credentials
+  labels:
+    product: ibm-storage-enabler-for-containers
+    # Ubiquity database credentials needed for ubiquity and ubiquity-db deployments
+    # Attention:
+    #      These settings will configure the database properties during the initial installation.
+    #      If these settings need to be changed after installation, configure them manually in the ubiqutiy-db postgres as well.
+type: Opaque
+data:
+   # Base64-encoded username to be set for the ubiquity-db deployment.
+   username: {{ .Values.GenericConfig.ubiquityPersistency.ubiquityDbCredentials.username | quote }}
+
+   # Base64-encoded password to be set for the ubiquity-db deployment.
+   password: {{ .Values.GenericConfig.ubiquityPersistency.ubiquityDbCredentials.password | b64enc | quote }}
+
+   # Base64-encoded database name ("dWJpcXVpdHk=" base64 is "ubiquity") to be created for the ubiquity-db deployment.
+   dbname: "dWJpcXVpdHk="

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
@@ -41,21 +41,24 @@ spec:
           - name: ibm-ubiquity-db
             mountPath: "/var/lib/postgresql/data"
             subPath: "ibm-ubiquity"
-# Certificate Set : use the below volumeMounts only if predefine certificate given
-# Cert #          - name: ubiquity-db-private-certificate
-# Cert #            mountPath: /var/lib/postgresql/ssl/private/
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+          - name: ubiquity-db-private-certificate
+            mountPath: /var/lib/postgresql/ssl/private/
+{{ end }}
+
       volumes:
       - name: ibm-ubiquity-db
         persistentVolumeClaim:
           claimName: ibm-ubiquity-db
-# Certificate Set : use the below volumes only if predefine certificate given
-# Cert #      - name: ubiquity-db-private-certificate
-# Cert #        secret:
-# Cert #          secretName: ubiquity-db-private-certificate
-# Cert #          items:
-# Cert #          - key: ubiquity-db.key
-# Cert #            path: ubiquity-db.key
-# Cert #            mode: 0600
-# Cert #          - key: ubiquity-db.crt
-# Cert #            path: ubiquity-db.crt
-# Cert #            mode: 0600
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+      - name: ubiquity-db-private-certificate
+        secret:
+          secretName: ubiquity-db-private-certificate
+          items:
+          - key: ubiquity-db.key
+            path: ubiquity-db.key
+            mode: 0600
+          - key: ubiquity-db.crt
+            path: ubiquity-db.crt
+            mode: 0600
+{{ end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
@@ -1,0 +1,61 @@
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: ubiquity-db
+  labels:
+    product: ibm-storage-enabler-for-containers
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ubiquity-db
+        product: ibm-storage-enabler-for-containers
+    spec:
+      containers:
+      - name: ubiquity-db
+        image: {{ .Values.images.ubiquitydb }}
+        ports:
+        - containerPort: 5432
+          name: ubiq-db-port  # no more then 15 chars
+        env:
+          - name: UBIQUITY_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: username
+
+          - name: UBIQUITY_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: password
+
+          - name: UBIQUITY_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: dbname
+
+        volumeMounts:
+          - name: ibm-ubiquity-db
+            mountPath: "/var/lib/postgresql/data"
+            subPath: "ibm-ubiquity"
+# Certificate Set : use the below volumeMounts only if predefine certificate given
+# Cert #          - name: ubiquity-db-private-certificate
+# Cert #            mountPath: /var/lib/postgresql/ssl/private/
+      volumes:
+      - name: ibm-ubiquity-db
+        persistentVolumeClaim:
+          claimName: ibm-ubiquity-db
+# Certificate Set : use the below volumes only if predefine certificate given
+# Cert #      - name: ubiquity-db-private-certificate
+# Cert #        secret:
+# Cert #          secretName: ubiquity-db-private-certificate
+# Cert #          items:
+# Cert #          - key: ubiquity-db.key
+# Cert #            path: ubiquity-db.key
+# Cert #            mode: 0600
+# Cert #          - key: ubiquity-db.crt
+# Cert #            path: ubiquity-db.crt
+# Cert #            mode: 0600

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
@@ -1,0 +1,16 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "ibm-ubiquity-db"
+  annotations:
+    volume.beta.kubernetes.io/storage-class: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
+  labels:
+    pv-name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}   # Ubiquity provisioner will create a PV with dedicated name (by default its ibm-ubiquity-db)
+    product: ibm-storage-enabler-for-containers
+
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-service.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ubiquity-db
+  labels:
+    app: ubiquity-db
+    product: ibm-storage-enabler-for-containers
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    app: ubiquity-db

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
@@ -137,33 +137,33 @@ spec:
                 name: ubiquity-configmap
                 key: SSL-MODE
 
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+        volumeMounts:
+        - name: ubiquity-private-certificate
+          mountPath: /var/lib/ubiquity/ssl/private
+          readOnly: true
+        - name: ubiquity-public-certificates
+          mountPath: /var/lib/ubiquity/ssl/public
+          readOnly: true
 
-# Certificate Set : use the below volumeMounts and volumes only if predefine certificate given
-# Cert #        volumeMounts:
-# Cert #        - name: ubiquity-private-certificate
-# Cert #          mountPath: /var/lib/ubiquity/ssl/private
-# Cert #          readOnly: true
-# Cert #        - name: ubiquity-public-certificates
-# Cert #          mountPath: /var/lib/ubiquity/ssl/public
-# Cert #          readOnly: true
-# Cert #
-# Cert #      volumes:
-# Cert #      - name: ubiquity-private-certificate
-# Cert #        secret:
-# Cert #          secretName: ubiquity-private-certificate
-# Cert #          items:
-# Cert #          - key: ubiquity.crt
-# Cert #            path: ubiquity.crt
-# Cert #            mode: 0600
-# Cert #          - key: ubiquity.key
-# Cert #            path: ubiquity.key
-# Cert #            mode: 0600
-# Cert #      - name: ubiquity-public-certificates
-# Cert #        configMap:
-# Cert #          name: ubiquity-public-certificates
-# Cert #          items:
-# Cert #          - key: ubiquity-db-trusted-ca.crt
-# Cert #            path: ubiquity-db-trusted-ca.crt
-# Cert #          - key: scbe-trusted-ca.crt
-# Cert #            path: scbe-trusted-ca.crt
+      volumes:
+      - name: ubiquity-private-certificate
+        secret:
+          secretName: ubiquity-private-certificate
+          items:
+          - key: ubiquity.crt
+            path: ubiquity.crt
+            mode: 0600
+          - key: ubiquity.key
+            path: ubiquity.key
+            mode: 0600
+      - name: ubiquity-public-certificates
+        configMap:
+          name: ubiquity-public-certificates
+          items:
+          - key: ubiquity-db-trusted-ca.crt
+            path: ubiquity-db-trusted-ca.crt
+          - key: scbe-trusted-ca.crt
+            path: scbe-trusted-ca.crt
+{{ end }}
 

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
@@ -1,0 +1,169 @@
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: ubiquity
+  labels:
+    product: ibm-storage-enabler-for-containers
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ubiquity
+        product: ibm-storage-enabler-for-containers
+    spec:
+      containers:
+      - name: ubiquity
+        image: {{ .Values.images.ubiquity }}
+        ports:
+        - containerPort: 9999
+          name: ubiquity-port
+        env:
+          ### Spectrum Connect(previously known as SCBE) connectivity parameters:
+          #############################################
+          - name: SCBE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: username
+
+          - name: SCBE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: password
+
+          - name: SCBE_SSL_MODE            # Values : require/verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+          - name: SCBE_MANAGEMENT_IP
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SCBE-MANAGEMENT-IP
+
+          - name: SCBE_MANAGEMENT_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SCBE-MANAGEMENT-PORT
+
+
+
+          ### Ubiquity Spectrum Connect(previously known as SCBE) backend parameters:
+          #####################################
+          - name: SCBE_DEFAULT_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SCBE-DEFAULT-SERVICE
+
+          - name: DEFAULT_VOLUME_SIZE
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: DEFAULT-VOLUME-SIZE
+
+          - name: UBIQUITY_INSTANCE_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: UBIQUITY-INSTANCE-NAME
+
+          - name: DEFAULT_FSTYPE    # ext4 or xfs
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: DEFAULT-FSTYPE
+
+          - name: IBM_UBIQUITY_DB_PV_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: IBM-UBIQUITY-DB-PV-NAME
+
+
+
+          ### Ubiquity generic parameters:
+          ################################
+          - name: LOG_LEVEL         # debug / info / error
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: LOG-LEVEL
+
+          - name: PORT              # Ubiquity port
+            value: "9999"
+          - name: LOG_PATH          # Ubiquity log file directory
+            value: "/tmp"
+          - name: DEFAULT_BACKEND   # "IBM Storage Enabler for Containers" supports "scbe" (Spectrum Connect) as its backend.
+            value: "scbe"
+
+
+
+          ### Ubiquity DB parameters:
+          ###########################
+          - name: UBIQUITY_DB_PSQL_HOST   # Ubiquity DB hostname, should point to the ubiquity-db service name
+            value: "ubiquity-db"
+          - name: UBIQUITY_DB_PSQL_PORT   # Ubiquity DB port, should point to the ubiquity-db port
+            value: "5432"
+          - name: UBIQUITY_DB_CONNECT_TIMEOUT
+            value: "3"
+
+          - name: UBIQUITY_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: username
+
+          - name: UBIQUITY_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: password
+
+          - name: UBIQUITY_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: dbname
+
+          - name: UBIQUITY_DB_SSL_MODE         # Values : require/verify-full. The default is disable # TODO verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+
+# Certificate Set : use the below volumeMounts and volumes only if predefine certificate given
+# Cert #        volumeMounts:
+# Cert #        - name: ubiquity-private-certificate
+# Cert #          mountPath: /var/lib/ubiquity/ssl/private
+# Cert #          readOnly: true
+# Cert #        - name: ubiquity-public-certificates
+# Cert #          mountPath: /var/lib/ubiquity/ssl/public
+# Cert #          readOnly: true
+# Cert #
+# Cert #      volumes:
+# Cert #      - name: ubiquity-private-certificate
+# Cert #        secret:
+# Cert #          secretName: ubiquity-private-certificate
+# Cert #          items:
+# Cert #          - key: ubiquity.crt
+# Cert #            path: ubiquity.crt
+# Cert #            mode: 0600
+# Cert #          - key: ubiquity.key
+# Cert #            path: ubiquity.key
+# Cert #            mode: 0600
+# Cert #      - name: ubiquity-public-certificates
+# Cert #        configMap:
+# Cert #          name: ubiquity-public-certificates
+# Cert #          items:
+# Cert #          - key: ubiquity-db-trusted-ca.crt
+# Cert #            path: ubiquity-db-trusted-ca.crt
+# Cert #          - key: scbe-trusted-ca.crt
+# Cert #            path: scbe-trusted-ca.crt
+

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
@@ -88,11 +88,11 @@ spec:
 
         - name: flex-log-dir
           mountPath: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
-# Certificate Set : use the below volumeMounts only if predefine certificate given
-# Cert #        - name: ubiquity-public-certificates
-# Cert #          mountPath: /var/lib/ubiquity/ssl/public
-# Cert #          readOnly: true
-
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+        - name: ubiquity-public-certificates
+          mountPath: /var/lib/ubiquity/ssl/public
+          readOnly: true
+{{ end }}
       volumes:
       - name: host-k8splugindir
         hostPath:
@@ -101,12 +101,13 @@ spec:
       - name: flex-log-dir
         hostPath:
           path: {{ .Values.genericConfig.logging.flexLogDir | quote  }}  # This directory must exist on the host
-# Certificate Set : use the below volumes only if predefine certificate given
-# Cert #      - name: ubiquity-public-certificates
-# Cert #        configMap:
-# Cert #          name: ubiquity-public-certificates
-# Cert #          items:
-# Cert #            - key: ubiquity-trusted-ca.crt
-# Cert #              path: ubiquity-trusted-ca.crt
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+      - name: ubiquity-public-certificates
+        configMap:
+          name: ubiquity-public-certificates
+          items:
+            - key: ubiquity-trusted-ca.crt
+              path: ubiquity-trusted-ca.crt
+{{ end }}
 
 #      nodeSelector:    # use this tag to target specific nodes in the cluster for flex installation

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
@@ -1,0 +1,112 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: ubiquity-k8s-flex
+  labels:
+    app: ubiquity-k8s-flex
+    product: ibm-storage-enabler-for-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ubiquity-k8s-flex
+        product: ibm-storage-enabler-for-containers
+    spec:
+      tolerations:   # Create flex Pods also on master nodes (even if there are NoScheduled nodes)
+      # Some k8s versions use dedicated key for toleration of the master and some use node-role.kubernetes.io/master key.
+      - key: dedicated
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: ubiquity-k8s-flex
+        image: {{ .Values.images.flex }}
+        env:
+          - name: UBIQUITY_PORT     # Ubiquity port, should point to the ubiquity service port
+            value: "9999"
+
+          - name: UBIQUITY_BACKEND         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
+            value: "scbe"
+
+          - name: FLEX_LOG_DIR    # /var/log default
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: FLEX-LOG-DIR
+
+          - name: FLEX_LOG_ROTATE_MAXSIZE # 50MB default
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: FLEX-LOG-ROTATE-MAXSIZE
+
+          - name: LOG_LEVEL       # debug / info / error
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: LOG-LEVEL
+
+          - name: UBIQUITY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: username
+
+          - name: UBIQUITY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: password
+
+          - name: UBIQUITY_PLUGIN_SSL_MODE   # require / verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+          - name: UBIQUITY_IP_ADDRESS   # The ubiquity service IP. The flex pod will update this IP inside the flex config file
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: UBIQUITY-IP-ADDRESS
+
+          - name: SKIP_RESCAN_ISCSI       # boolean
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SKIP-RESCAN-ISCSI
+
+
+
+        command: ["./setup_flex.sh"]
+        volumeMounts:
+        - name: host-k8splugindir
+          mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+
+        - name: flex-log-dir
+          mountPath: {{ .Values.GenericConfig.logging.flexLogDir | quote  }}
+# Certificate Set : use the below volumeMounts only if predefine certificate given
+# Cert #        - name: ubiquity-public-certificates
+# Cert #          mountPath: /var/lib/ubiquity/ssl/public
+# Cert #          readOnly: true
+
+      volumes:
+      - name: host-k8splugindir
+        hostPath:
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec  # This directory must exist on the host
+
+      - name: flex-log-dir
+        hostPath:
+          path: {{ .Values.GenericConfig.logging.flexLogDir | quote  }}  # This directory must exist on the host
+# Certificate Set : use the below volumes only if predefine certificate given
+# Cert #      - name: ubiquity-public-certificates
+# Cert #        configMap:
+# Cert #          name: ubiquity-public-certificates
+# Cert #          items:
+# Cert #            - key: ubiquity-trusted-ca.crt
+# Cert #              path: ubiquity-trusted-ca.crt
+
+#      nodeSelector:    # use this tag to target specific nodes in the cluster for flex installation

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
@@ -87,7 +87,7 @@ spec:
           mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
 
         - name: flex-log-dir
-          mountPath: {{ .Values.GenericConfig.logging.flexLogDir | quote  }}
+          mountPath: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
 # Certificate Set : use the below volumeMounts only if predefine certificate given
 # Cert #        - name: ubiquity-public-certificates
 # Cert #          mountPath: /var/lib/ubiquity/ssl/public
@@ -100,7 +100,7 @@ spec:
 
       - name: flex-log-dir
         hostPath:
-          path: {{ .Values.GenericConfig.logging.flexLogDir | quote  }}  # This directory must exist on the host
+          path: {{ .Values.genericConfig.logging.flexLogDir | quote  }}  # This directory must exist on the host
 # Certificate Set : use the below volumes only if predefine certificate given
 # Cert #      - name: ubiquity-public-certificates
 # Cert #        configMap:

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
@@ -1,0 +1,75 @@
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: ubiquity-k8s-provisioner
+  labels:
+    product: ibm-storage-enabler-for-containers
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ubiquity-k8s-provisioner
+        product: ibm-storage-enabler-for-containers
+    spec:
+      containers:
+      - name: ubiquity-k8s-provisioner
+        image: {{ .Values.images.provisioner }}
+        env:
+          - name: UBIQUITY_ADDRESS  # Ubiquity hostname, should point to the ubiquity service name
+            value: "ubiquity"
+          - name: UBIQUITY_PORT     # Ubiquity port, should point to the ubiquity service port
+            value: "9999"
+          - name: KUBECONFIG
+            value: "/tmp/k8sconfig/config"
+          - name: RETRIES          # number of retries on failure
+            value: "1"
+          - name: LOG_PATH         # provisioner log file directory
+            value: "/tmp"
+          - name: BACKENDS         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
+            value: "scbe"
+
+          - name: LOG_LEVEL       # debug / info / error
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: LOG-LEVEL
+
+          - name: UBIQUITY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: username
+
+          - name: UBIQUITY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: password
+
+          - name: UBIQUITY_PLUGIN_SSL_MODE   # require / verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+        volumeMounts:
+          - name: k8s-config
+            mountPath: /tmp/k8sconfig
+# Certificate Set : use the below volumeMounts only if predefine certificate given
+# Cert #          - name: ubiquity-public-certificates
+# Cert #            mountPath: /var/lib/ubiquity/ssl/public
+# Cert #            readOnly: true
+
+      volumes:
+        - name: k8s-config
+          configMap:
+            name: k8s-config
+# Certificate Set : use the below volumes only if predefine certificate given
+# Cert #        - name: ubiquity-public-certificates
+# Cert #          configMap:
+# Cert #            name: ubiquity-public-certificates
+# Cert #            items:
+# Cert #              - key: ubiquity-trusted-ca.crt
+# Cert #                path: ubiquity-trusted-ca.crt
+

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
@@ -56,20 +56,22 @@ spec:
         volumeMounts:
           - name: k8s-config
             mountPath: /tmp/k8sconfig
-# Certificate Set : use the below volumeMounts only if predefine certificate given
-# Cert #          - name: ubiquity-public-certificates
-# Cert #            mountPath: /var/lib/ubiquity/ssl/public
-# Cert #            readOnly: true
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+          - name: ubiquity-public-certificates
+            mountPath: /var/lib/ubiquity/ssl/public
+            readOnly: true
+{{ end }}
 
       volumes:
         - name: k8s-config
           configMap:
             name: k8s-config
-# Certificate Set : use the below volumes only if predefine certificate given
-# Cert #        - name: ubiquity-public-certificates
-# Cert #          configMap:
-# Cert #            name: ubiquity-public-certificates
-# Cert #            items:
-# Cert #              - key: ubiquity-trusted-ca.crt
-# Cert #                path: ubiquity-trusted-ca.crt
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+        - name: ubiquity-public-certificates
+          configMap:
+            name: ubiquity-public-certificates
+            items:
+              - key: ubiquity-trusted-ca.crt
+                path: ubiquity-trusted-ca.crt
+{{ end }}
 

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-namespace.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-namespace.yml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ubiquity
-  labels:
-     product: ibm-storage-enabler-for-containers

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-namespace.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ubiquity
+  labels:
+     product: ibm-storage-enabler-for-containers

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-service.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-service.yml
@@ -1,14 +1,14 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: ubiquity
-  labels:
-    app: ubiquity
-    product: ibm-storage-enabler-for-containers
-spec:
-  ports:
-    - port: 9999
-      protocol: TCP
-      targetPort: 9999
-  selector:
-    app: ubiquity
+#apiVersion: v1
+#kind: Service
+#metadata:
+#  name: ubiquity
+#  labels:
+#    app: ubiquity
+#    product: ibm-storage-enabler-for-containers
+#spec:
+#  ports:
+#    - port: 9999
+#      protocol: TCP
+#      targetPort: 9999
+#  selector:
+#    app: ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-service.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ubiquity
+  labels:
+    app: ubiquity
+    product: ibm-storage-enabler-for-containers
+spec:
+  ports:
+    - port: 9999
+      protocol: TCP
+      targetPort: 9999
+  selector:
+    app: ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -1,0 +1,62 @@
+# ----------------------------------------------------
+# Helm chart to install IBM storage Enabler for Containers.
+# ----------------------------------------------------
+
+images:
+  ubiquity: ibmcom/ibm-storage-enabler-for-containers:2.0.0
+  ubiquitydb: ibmcom/ibm-storage-enabler-for-containers-db:2.0.0
+  provisioner: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes:2.0.0
+  flex: ibmcom/ibm-storage-flex-volume-for-kubernetes:2.0.0
+
+spectrumConnect:
+  connectionInfo:
+    # IP\FQDN and port of Spectrum Connect server.
+    fqdn=
+    port=8440
+    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
+    username=
+    password=
+    # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
+    sslMode=
+
+  backendConfig:
+    # A prefix for any new volume created on the storage system.
+    instanceName=
+    # Allowed values: true or false. Set to true if the nodes have FC connectivity.
+    skipRescanIscsi=false
+    # Default Spectrum Connect storage service to be used, if not specified by the storage class.
+    DefaultStorageService=
+
+    newVolumeDefaults:
+      # The fstype of a new volume if not specified by the user in the storage class.
+      # File system type. Allowed values: ext4 or xfs.
+      fsType=ext4
+      # The default volume size (in GB) if not specified by the user when creating a new volume.
+      size=1
+
+    dbPvConfig:
+      # Ubiquity database PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
+      # For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
+      ubiquityDbPvName=ibm-ubiquity-db
+
+      storageClassForDbPv:
+        # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
+        storageClassName=
+        params:
+          # Storage Class profile parameter should point to the Spectrum Connect storage service name
+          spectrumConnectServiceName=
+          # Storage Class file-system type, Allowed values: ext4 or xfs.
+          fsType=ext4
+
+
+GenericConfig:
+  logging:
+    # Log level. Allowed values: debug, info, error.
+    logLevel=info
+    # Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
+    flexLogDir=/var/log
+
+  ubiquityDbCredentials:
+    # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
+    username=ubiquity
+    password=ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -10,61 +10,65 @@ images:
 
 spectrumConnect:
   connectionInfo:
-    # IP\FQDN and port of Spectrum Connect server.
-    fqdn=
-    port=8440
-    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
-    username=
-    password=
+    ## IP\FQDN and port of Spectrum Connect server.
+    fqdn:
+    port:
+
+    ## Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
+    username:
+    password:
+
     # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
-    sslMode=
+    sslMode: require
 
   backendConfig:
     # A prefix for any new volume created on the storage system.
-    instanceName=
+    instanceName:
     # Allowed values: true or false. Set to true if the nodes have FC connectivity.
-    skipRescanIscsi=false
+    skipRescanIscsi: false
     # Default Spectrum Connect storage service to be used, if not specified by the storage class.
-    DefaultStorageService=
+    DefaultStorageService:
 
     newVolumeDefaults:
       # The fstype of a new volume if not specified by the user in the storage class.
       # File system type. Allowed values: ext4 or xfs.
-      fsType=ext4
+      fsType: ext4
       # The default volume size (in GB) if not specified by the user when creating a new volume.
-      size=1
+      size: 1
 
     dbPvConfig:
       # Ubiquity database PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
       # For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
-      ubiquityDbPvName=ibm-ubiquity-db
+      ubiquityDbPvName: ibm-ubiquity-db
 
       storageClassForDbPv:
         # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
-        storageClassName=
+        storageClassName:
         params:
           # Storage Class profile parameter should point to the Spectrum Connect storage service name
-          spectrumConnectServiceName=
+          spectrumConnectServiceName:
           # Storage Class file-system type, Allowed values: ext4 or xfs.
-          fsType=ext4
+          fsType: ext4
 
 genericConfig:
   # The IP address of the ubiquity service object.
   # The user must update this key manually if the ubiqutiy service object IP was changed.
-  ubiquityIpAddress=
+  ubiquityIpAddress:
 
   logging:
     # Log level. Allowed values: debug, info, error.
-    logLevel=info
+    logLevel: info
     # Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
-    flexLogDir=/var/log
+    flexLogDir: /var/log
 
   ubiquityDbCredentials:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
-    username=ubiquity
-    password=ubiquity
+    username:
+    password:
 
   k8sApiServerAccess:
     # The provisioner will use it to access API server in order to create\delete\view PVCs
-    server=
-    token=
+    # server from the .kube/config
+    server:
+    # token from kubectl -n default get secret $(kubectl -n default get secret | grep service-account | awk '{print $1}') -o yaml | grep token: | awk '{print $2}' | base64 -d
+    token:

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -48,8 +48,11 @@ spectrumConnect:
           # Storage Class file-system type, Allowed values: ext4 or xfs.
           fsType=ext4
 
+genericConfig:
+  # The IP address of the ubiquity service object.
+  # The user must update this key manually if the ubiqutiy service object IP was changed.
+  ubiquityIpAddress=
 
-GenericConfig:
   logging:
     # Log level. Allowed values: debug, info, error.
     logLevel=info
@@ -60,3 +63,8 @@ GenericConfig:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
     username=ubiquity
     password=ubiquity
+
+  k8sApiServerAccess:
+    # The provisioner will use it to access API server in order to create\delete\view PVCs
+    server=
+    token=

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -66,9 +66,10 @@ genericConfig:
     username:
     password:
 
-  k8sApiServerAccess:
-    # The provisioner will use it to access API server in order to create\delete\view PVCs
-    # server from the .kube/config
-    server:
-    # token from kubectl -n default get secret $(kubectl -n default get secret | grep service-account | awk '{print $1}') -o yaml | grep token: | awk '{print $2}' | base64 -d
-    token:
+#  k8sApiServerAccess:
+#    # The provisioner will use it to access API server in order to create\delete\view PVCs
+#
+#    # server from the .kube/config
+#    server:
+#    # token from kubectl -n default get secret $(kubectl -n default get secret | grep service-account | awk '{print $1}') -o yaml | grep token: | awk '{print $2}' | base64 -d
+#    token:


### PR DESCRIPTION
**Description**
Provide a basic helm chart for ubiqutiy instead of the the original ubiquity_installer.sh script.
Its just the first step to word a fully function helm chart, so its just the phase1. This phase1 will have some limitations to operation - some manual operations needed to be done before install or uninstall.

**helm chart tree**
./helm_chart
└── ibm_storage_enabler_for_containers
    ├── charts
    ├── Chart.yaml
    ├── NOTES.txt        ### place holder for now
    ├── README.md    ### Not with the final text yet
    ├── templates
    │   ├── k8s-config-configmap.yml
    │   ├── scbe-credentials-secret.yml
    │   ├── storage-class.yml
    │   ├── ubiquity-configmap.yml
    │   ├── ubiquity-db-credentials-secret.yml
    │   ├── ubiquity-db-deployment.yml
    │   ├── ubiquity-db-pvc.yml
    │   ├── ubiquity-db-service.yml
    │   ├── ubiquity-deployment.yml
    │   ├── ubiquity-k8s-flex-daemonset.yml
    │   ├── ubiquity-k8s-provisioner-deployment.yml
    │   └── ubiquity-service.yml
    └── values.yaml    


**Limitations for the phase1 helm chart:**
1. Before install the helm, you need to create ubiqutiy service and namespace objects (automatic set the service IP in the values will be done in later PR)
2. Before uninstall the helm, you need to delete manually the ubiquity-db and ubiqutiy-db-pvc (Using fixed order for uninstall will be done in later PR)
3. The helm install will take 1minutes because the provisioner deployment gets up before ubiqutiy deployment. (it will be fixed in later PR)
4. helm sanity is not included in this PR (will be done in later PR)
5. The helm include only Spectrum Connect backend support. Scale support will be added in later PR.


**values.yaml**
This file is basically like the old ubiqutiy_installer.conf file, but with helm like standard and with better separation and canonization of the keys. 
- All the Spectrum Connect ubiqutiy backend settings are under "spectrumConnect" key.
- All the generic part of ubiquity framework settings are under the "genericConfig" key.
- All the image names are under "images" key.



**Here is how to use this phase1 ubiquity helm chart:**
**======================================**
#On the master node do the following:

**# Pre requisites before installation**
```
#copy helm chart 
export HOST=<host where you can find the ubiquity-k8s repository>
cd /var/tmp
scp -r $HOST/ubiquity-k8s/helm_chart /var/tmp/
 
#for ubiqutiy provisioner (later will be replaced by service account)
cp ~/.kube/config    /var/tmp/helm_chart/ibm_storage_enabler_for_containers

#create ubiqutiy namespace (in order to create the ubiqutiy service for getting the IP in advance for the flex deamonset)

cat <<EOF | kubectl create -f -
apiVersion: v1
kind: Namespace
metadata:
  name: ubiquity
  labels:
     product: ibm-storage-enabler-for-containers
EOF

cat <<EOF | kubectl create -n ubiquity -f -
apiVersion: v1
kind: Service
metadata:
  name: ubiquity
  labels:
    app: ubiquity
    product: ibm-storage-enabler-for-containers
spec:
  ports:
    - port: 9999
      protocol: TCP
      targetPort: 9999
  selector:
    app: ubiquity
EOF

kubectl get svc -n ubiquity

#update values.yaml with the right values + the IP of the ubiqutiy service (ubiquityIpAddress)
vi /var/tmp/helm_chart/ibm_storage_enabler_for_containers/values.yaml
```




**# Installation phase:**
#-----------------------------
```
helm install ./ibm_storage_enabler_for_containers -f ./ibm_storage_enabler_for_containers/myvalues.yaml  --name ubiquity --namespace ubiquity
#NOTE: it will take 2 minutes because the provision stuck first due to ubiqutiy service is not up yet.  So to avoid waiting, one can just kill the provisioner pod so it will start again and succeed.  if needed you can wait just 2 minute and it will go up.
helm ls 
helm status ubiquity
#wait until status is OK and all pods up
```



**# tear down:**
#-------------------
#Because in helm phase1 there is no uninstall dependancies, then one should do the followign steps to uninstall ubiqutiy helm:
```
kubectl delete deploy/ubiquity-db -n ubiquity		# to avoid zomby db deployment in terminating state
#wait until ubiquity-db pod is down :  kubectl get -n ubiquity deploy/ubiquity-db

kubectl delete -n ubiquity pvc/ibm-ubiquity-db			    # to avod zomby pv object
#wait until pvc deleted    : kubectl get -n ubiquity pvc/ibm-ubiquity-db

helm delete --purge ubiquity
kubectl delete svc -n ubiquity ubiquity
kubectl delete ns ubiquity
```






<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/213)
<!-- Reviewable:end -->
