### PR TITLE
Upgrade to Alpine 3.8 and ca-certificates-20171114-r3

### DIFF
--- a/Dockerfile.Flex
+++ b/Dockerfile.Flex
@@ -7,8 +7,8 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode external -extldflags "-static"' -installsuffix cgo -o ubiquity-k8s-flex cmd/flex/main/cli.go
 
 
-FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0
+FROM alpine:3.8
+RUN apk --no-cache add ca-certificates=20171114-r3
 ENV UBIQUITY_PLUGIN_VERIFY_CA=/var/lib/ubiquity/ssl/public/ubiquity-trusted-ca.crt
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity-k8s/ubiquity-k8s-flex .

--- a/Dockerfile.Provisioner
+++ b/Dockerfile.Provisioner
@@ -7,8 +7,8 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode external -extldflags "-static"' -installsuffix cgo -o ubiquity-k8s-provisioner cmd/provisioner/main/main.go
 
 
-FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0
+FROM alpine:3.8
+RUN apk --no-cache add ca-certificates=20171114-r3
 ENV UBIQUITY_PLUGIN_VERIFY_CA=/var/lib/ubiquity/ssl/public/ubiquity-trusted-ca.crt
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity-k8s/ubiquity-k8s-provisioner .

--- a/glide.yaml
+++ b/glide.yaml
@@ -110,7 +110,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 1a9cae43fc45e57019989c11737eb34d8a38db0d
+  version: 1c0104b66f5f882340b1b5d7d3e0a6a269a1d5a7
   subpackages:
   - remote
   - resources


### PR DESCRIPTION
1. upgrade ubiqutiy server from Alpine 3.7 to 3.8
2. Due to Alpine upgrade, we should upgrafr ca-certificates from 20171114-r0 to 20171114-r3.(To aligned based on list mentioned [HERE](http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/)

Also related to https://github.com/IBM/ubiquity/pull/251

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/217)
<!-- Reviewable:end -->
