### PR TITLE
Feature/install ubiquity with helm

### DIFF
--- a/helm_chart/ibm_storage_enabler_for_containers/.helmignore
+++ b/helm_chart/ibm_storage_enabler_for_containers/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm_chart/ibm_storage_enabler_for_containers/Chart.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for IBM Storage Enabler for Containers
+name: ibm-storage-enalber-for-containers
+version: 2.0.0

--- a/helm_chart/ibm_storage_enabler_for_containers/Chart.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for IBM Storage Enabler for Containers
-name: ibm-storage-enalber-for-containers
+name: ibm-storage-enable-for-containers
 version: 2.0.0

--- a/helm_chart/ibm_storage_enabler_for_containers/README.md
+++ b/helm_chart/ibm_storage_enabler_for_containers/README.md
@@ -1,0 +1,4 @@
+Helm Chart for IBM Storage Enabler for Containers
+
+Before installing this Helm Chart you must preform the prerequisite mentioned in IBM Storage Enabler for Containers user guide.
+https://www-945.ibm.com/support/fixcentral/swg/selectFixes?parent=Software%2Bdefined%2Bstorage&product=ibm/StorageSoftware/IBM+Spectrum+Connect&release=All&platform=Linux&function=all

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/_helpers.tpl
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/_helpers.tpl
@@ -46,9 +46,9 @@ Create the name for the scbe secret
 Create the name for ubiquity-db secret                                                                                                                                                 
 */}}                                                                                                                                                                         
 {{- define "ibm_storage_enabler_for_containers.ubiquityDbCredentials" -}}                  
-    {{- if .Values.GenericConfig.ubiquityDbCredentials.existingSecret -}}
-        {{- .Vaules.GenericConfig.ubiquityDbCredentials.existingSecret -}}
+    {{- if .Values.genericConfig.ubiquityDbCredentials.existingSecret -}}
+        {{- .Vaules.genericConfig.ubiquityDbCredentials.existingSecret -}}
     {{- else -}}
-        {{- template "ibm_storage_enabler_for_containers.fullname" . -}}-ubiquityDB 
+        {{- template "ibm_storage_enabler_for_containers.fullname" . -}}-ubiquitydb 
     {{- end -}}                                                                                                        
 {{- end -}}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/cluster-role-binding.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/cluster-role-binding.yml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ubiquity
+  labels:
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ubiquity
+subjects:
+- kind: ServiceAccount
+  name: ubiquity
+  namespace: ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/cluster-role.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/cluster-role.yml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ubiquity
+  labels:
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - create
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - get
+  - list
+  - create
+  - patch

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-config
+  labels:
+    product: ibm-storage-enabler-for-containers
+data:
+  # TODO later on we will replace this with service account and RBAC, but for phase1 its good enough
+  config: |
+{{ .Files.Get "config" | indent 4 }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/k8s-config-configmap.yml
@@ -2,8 +2,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k8s-config
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
   # TODO later on we will replace this with service account and RBAC, but for phase1 its good enough
   config: |

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/post-install-job.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/post-install-job.yml
@@ -7,8 +7,8 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
   namespace: ubiquity
   labels:
-    app: {{ template "ubiquity.name" . }}
-    chart: {{ template "ubiquity.chart" . }}
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -41,7 +41,7 @@ spec:
         - name: UBIQUITY_IP
           value: "echo $GET_RESPONSE | awk -F 'clusterIP\": ' '{print $2}' | awk -F ',' '{print $1}'"
         - name: PATCH_BODY
-          value: '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"normal\"}],\"containers\":[{\"env\":[{\"name\":\"UBIQUITY_IP_ADDRESS\"}],\"env\":[{\"name\":\"UBIQUITY_IP_ADDRESS\",\"value\":$UBIQUITY_IP_ADDRESS,\"valueFrom\":null}],\"name\":\"normal\"}]}}}}'
+          value: '{\"spec\":{\"template\":{\"spec\":{\"$setElementOrder/containers\":[{\"name\":\"ubiquity-k8s-flex\"}],\"containers\":[{\"$setElementOrder/env\":[{\"name\":\"UBIQUITY_PORT\"},{\"name\":\"UBIQUITY_BACKEND\"},{\"name\":\"FLEX_LOG_DIR\"},{\"name\":\"FLEX_LOG_ROTATE_MAXSIZE\"},{\"name\":\"LOG_LEVEL\"},{\"name\":\"UBIQUITY_USERNAME\"},{\"name\":\"UBIQUITY_PASSWORD\"},{\"name\":\"UBIQUITY_PLUGIN_SSL_MODE\"},{\"name\":\"UBIQUITY_IP_ADDRESS\"},{\"name\":\"SKIP_RESCAN_ISCSI\"}],\"env\":[{\"name\":\"UBIQUITY_IP_ADDRESS\",\"value\":$UBIQUITY_IP_ADDRESS,\"valueFrom\":null}],\"name\":\"ubiquity-k8s-flex\"}]}}}}'
         - name: PATCH_DAEMONSET_IP
           value: "curl -k --cacert /var/run/secrets/kubernetes.io/serviceaccout/ca.crt -H \"$(AUTH)\" -H \"$(ACCEPT)\" -H \"$(CONTENT_TYPE)\" -X PATCH --data $(PATCH_BODY) $(DAEMONSET_URL)"
         - name: TITLE
@@ -49,7 +49,7 @@ spec:
         - name: DELIMITER
           value: "--------------------------------------------------------"
         command: ["/bin/sh"]
-        args: ["-c", "echo -e '$(DELIMITER)\n$(TITLE)\n$(DELIMITER)'; TOKEN_VALUE=`$(TOKEN)`; echo $(GET_SERVICE_IP); GET_RESPONSE=`$(GET_SERVICE_IP)`; UBIQUITY_IP_ADDRESS=`$(UBIQUITY_IP)`; echo 'UbiquityIP: '$UBIQUITY_IP_ADDRESS; echo $(PATCH_DAEMONSET_IP); PATCH=`$(PATCH_DAEMONSET_IP)`; echo 'Patch successfully!'"]
+        args: ["-c", "echo -e '$(DELIMITER)\n$(TITLE)\n$(DELIMITER)'; TOKEN_VALUE=`$(TOKEN)`; echo $(GET_SERVICE_IP); GET_RESPONSE=`$(GET_SERVICE_IP)`; UBIQUITY_IP_ADDRESS=`$(UBIQUITY_IP)`; echo 'UbiquityIP: '$UBIQUITY_IP_ADDRESS; echo $(PATCH_DAEMONSET_IP); PATCH=`$(PATCH_DAEMONSET_IP)`; echo $PATCH; echo 'Patch successfully!';"]
       restartPolicy: Never
       serviceAccount: ubiquity
   backoffLimit: 2

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/post-install-job.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/post-install-job.yml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-install-job
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  namespace: ubiquity
+  labels:
+    app: {{ template "ubiquity.name" . }}
+    chart: {{ template "ubiquity.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: hook
+        image: byrnedo/alpine-curl
+        env:
+        - name: KUBERNETES_DNS_RECORD
+          value: "kubernetes.default"
+        - name: TOKEN
+          value: "cat /var/run/secrets/kubernetes.io/serviceaccount/token"
+        - name: SERVICE_NAME
+          value: "ubiquity"
+        - name: SERVICE_URL
+          value: "https://$(KUBERNETES_DNS_RECORD)/api/v1/namespaces/ubiquity/services/$(SERVICE_NAME)"
+        - name: DAEMONSET_NAME
+          value: "ubiquity-k8s-flex"
+        - name: DAEMONSET_URL
+          value: "https://$(KUBERNETES_DNS_RECORD)/apis/extensions/v1beta1/namespaces/ubiquity/daemonsets/$(DAEMONSET_NAME)"
+        - name: AUTH
+          value: "Authorization: Bearer $TOKEN_VALUE"
+        - name: ACCEPT
+          value: "Accept: application/json"
+        - name: CONTENT_TYPE
+          value: "Content-Type: application/strategic-merge-patch+json"
+        - name: GET_SERVICE_IP
+          value: "curl -k --cacert /var/run/secrets/kubernetes.io/serviceaccout/ca.crt -H \"$(AUTH)\" $(SERVICE_URL)"
+        - name: UBIQUITY_IP
+          value: "echo $GET_RESPONSE | awk -F 'clusterIP\": ' '{print $2}' | awk -F ',' '{print $1}'"
+        - name: PATCH_BODY
+          value: '{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"normal\"}],\"containers\":[{\"env\":[{\"name\":\"UBIQUITY_IP_ADDRESS\"}],\"env\":[{\"name\":\"UBIQUITY_IP_ADDRESS\",\"value\":$UBIQUITY_IP_ADDRESS,\"valueFrom\":null}],\"name\":\"normal\"}]}}}}'
+        - name: PATCH_DAEMONSET_IP
+          value: "curl -k --cacert /var/run/secrets/kubernetes.io/serviceaccout/ca.crt -H \"$(AUTH)\" -H \"$(ACCEPT)\" -H \"$(CONTENT_TYPE)\" -X PATCH --data $(PATCH_BODY) $(DAEMONSET_URL)"
+        - name: TITLE
+          value: "Patch UBIQUITY_IP_ADDRESS in daemonset ubiquity-k8s-flex"
+        - name: DELIMITER
+          value: "--------------------------------------------------------"
+        command: ["/bin/sh"]
+        args: ["-c", "echo -e '$(DELIMITER)\n$(TITLE)\n$(DELIMITER)'; TOKEN_VALUE=`$(TOKEN)`; echo $(GET_SERVICE_IP); GET_RESPONSE=`$(GET_SERVICE_IP)`; UBIQUITY_IP_ADDRESS=`$(UBIQUITY_IP)`; echo 'UbiquityIP: '$UBIQUITY_IP_ADDRESS; echo $(PATCH_DAEMONSET_IP); PATCH=`$(PATCH_DAEMONSET_IP)`; echo 'Patch successfully!'"]
+      restartPolicy: Never
+      serviceAccount: ubiquity
+  backoffLimit: 2

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scbe-credentials
+  labels:
+    product: ibm-storage-enabler-for-containers
+# Spectrum Connect(previously known as SCBE) credentials needed for ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemonset.
+type: Opaque
+data:
+   # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
+   username: {{ .Values.spectrumConnect.connectionInfo.username | b64enc | quote  }}
+
+   # Base64-encoded password defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
+   password: {{ .Values.spectrumConnect.connectionInfo.password | b64enc | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "ibm_storage_enabler_for_containers.scbeCredentials" . }}
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
     app: {{ template "ibm_storage_enabler_for_containers.name" . }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/service-account.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/service-account.yml
@@ -1,18 +1,10 @@
 apiVersion: v1
-kind: Service
+kind: ServiceAccount
 metadata:
   name: ubiquity
   namespace: ubiquity
   labels:
-    app: ubiquity
-    product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
     chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-spec:
-  ports:
-    - port: 9999
-      protocol: TCP
-      targetPort: 9999
-  selector:
-    app: ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
@@ -1,0 +1,13 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
+  labels:
+    product: ibm-storage-enabler-for-containers
+#  annotations:
+#   storageclass.beta.kubernetes.io/is-default-class: "true"
+provisioner: "ubiquity/flex"
+parameters:
+  profile: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.params.spectrumConnectServiceName  | quote }}
+  fstype: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.params.fsType  | quote }}        # xfs or ext4
+  backend: "scbe"

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
@@ -2,8 +2,13 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 #  annotations:
 #   storageclass.beta.kubernetes.io/is-default-class: "true"
 provisioner: "ubiquity/flex"

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
@@ -3,8 +3,13 @@ kind: ConfigMap
 metadata:
 # IBM Storage Enabler for Containers Kubernetes daemonset and deployments settings.
   name: ubiquity-configmap
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 data:
    # The keys below are used by ubiquity deployment
    # -----------------------------------------------

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+# IBM Storage Enabler for Containers Kubernetes daemonset and deployments settings.
+  name: ubiquity-configmap
+  labels:
+    product: ibm-storage-enabler-for-containers
+data:
+   # The keys below are used by ubiquity deployment
+   # -----------------------------------------------
+   # IP or FQDN of Spectrum Connect(previously known as SCBE) server.
+   SCBE-MANAGEMENT-IP: {{ .Values.spectrumConnect.connectionInfo.fqdn | quote }}
+
+   # Communication port of Spectrum Connect server. Optional parameter with default value set at 8440.
+   SCBE-MANAGEMENT-PORT: {{ .Values.spectrumConnect.connectionInfo.port | quote }}
+
+   # Default Spectrum Connect storage service to be used, if not specified by the plugin.
+   SCBE-DEFAULT-SERVICE: {{ .Values.spectrumConnect.backendConfig.DefaultStorageService | quote }}
+
+   # The size for a new volume if not specified by the user when creating a new volume. Optional parameter with default value set at 1GB.
+   DEFAULT-VOLUME-SIZE: {{ .Values.spectrumConnect.backendConfig.newVolumeDefaults.size | quote }}
+
+   # A prefix for any new volume created on the storage system. Default value is None.
+   UBIQUITY-INSTANCE-NAME: {{ .Values.spectrumConnect.backendConfig.instanceName | quote }}
+
+   # File system type. Optional parameter with two allowed values: ext4 or xfs. Default value is ext4.
+   DEFAULT-FSTYPE: {{ .Values.spectrumConnect.backendConfig.newVolumeDefaults.fsType | quote }}
+
+   # DB pv name.
+   IBM-UBIQUITY-DB-PV-NAME: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}
+
+   # The following keys are used by ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemon-set
+   # ----------------------------------------------------------------------------------------------------------------------------
+   # Flex log path. Allow to configure it, just make sure the the new path exist on all the minons and update the hostpath in the Flex daemonset
+   FLEX-LOG-DIR: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
+
+   # Maxlog size(MB) for rotate
+   FLEX-LOG-ROTATE-MAXSIZE: "50"
+
+   # Log level. Allowed values: debug, info, error.
+   LOG-LEVEL: {{ .Values.genericConfig.logging.logLevel  | quote }}
+
+   # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
+   SSL-MODE: {{ .Values.spectrumConnect.connectionInfo.sslMode | quote }}
+
+
+   # The following keys are used by the ubiquity-k8s-flex daemonset
+   # --------------------------------------------------------------
+   # The IP address of the ubiquity service object. The ubiquity_installer.sh automatically updates this field during the initial installation.
+   # The user must update this key manually if the ubiqutiy service object IP was changed.
+   UBIQUITY-IP-ADDRESS: {{ .Values.genericConfig.ubiquityIpAddress | quote }}
+
+   # Allowed values: true or false. Set to true if the nodes have FC connectivity.
+   SKIP-RESCAN-ISCSI: {{ .Values.spectrumConnect.backendConfig.skipRescanIscsi | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
@@ -1,8 +1,9 @@
-{{- if not .Values.GenericConfig.ubiquityDbCredentials.existingSecret -}}
+{{- if not .Values.genericConfig.ubiquityDbCredentials.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "ibm_storage_enabler_for_containers.ubiquityDbCredentials" . }}
+  namespace: ubiquity
   labels:
     app: {{ template "ibm_storage_enabler_for_containers.name" . }}
     chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ubiquity-db-credentials
+  labels:
+    product: ibm-storage-enabler-for-containers
+    # Ubiquity database credentials needed for ubiquity and ubiquity-db deployments
+    # Attention:
+    #      These settings will configure the database properties during the initial installation.
+    #      If these settings need to be changed after installation, configure them manually in the ubiqutiy-db postgres as well.
+type: Opaque
+data:
+   # Base64-encoded username to be set for the ubiquity-db deployment.
+   username: {{ .Values.genericConfig.ubiquityDbCredentials.username | b64enc | quote }}
+
+   # Base64-encoded password to be set for the ubiquity-db deployment.
+   password: {{ .Values.genericConfig.ubiquityDbCredentials.password | b64enc | quote }}
+
+   # Base64-encoded database name ("dWJpcXVpdHk=" base64 is "ubiquity") to be created for the ubiquity-db deployment.
+   dbname: "dWJpcXVpdHk="

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
@@ -1,0 +1,64 @@
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: ubiquity-db
+  labels:
+    product: ibm-storage-enabler-for-containers
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ubiquity-db
+        product: ibm-storage-enabler-for-containers
+    spec:
+      containers:
+      - name: ubiquity-db
+        image: {{ .Values.images.ubiquitydb }}
+        ports:
+        - containerPort: 5432
+          name: ubiq-db-port  # no more then 15 chars
+        env:
+          - name: UBIQUITY_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: username
+
+          - name: UBIQUITY_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: password
+
+          - name: UBIQUITY_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: dbname
+
+        volumeMounts:
+          - name: ibm-ubiquity-db
+            mountPath: "/var/lib/postgresql/data"
+            subPath: "ibm-ubiquity"
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+          - name: ubiquity-db-private-certificate
+            mountPath: /var/lib/postgresql/ssl/private/
+{{ end }}
+
+      volumes:
+      - name: ibm-ubiquity-db
+        persistentVolumeClaim:
+          claimName: ibm-ubiquity-db
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+      - name: ubiquity-db-private-certificate
+        secret:
+          secretName: ubiquity-db-private-certificate
+          items:
+          - key: ubiquity-db.key
+            path: ubiquity-db.key
+            mode: 0600
+          - key: ubiquity-db.crt
+            path: ubiquity-db.crt
+            mode: 0600
+{{ end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
@@ -2,8 +2,13 @@ apiVersion: "extensions/v1beta1"
 kind: Deployment
 metadata:
   name: ubiquity-db
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: 1
   template:

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
@@ -2,11 +2,16 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: "ibm-ubiquity-db"
+  namespace: ubiquity
   annotations:
     volume.beta.kubernetes.io/storage-class: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
   labels:
     pv-name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}   # Ubiquity provisioner will create a PV with dedicated name (by default its ibm-ubiquity-db)
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 
 spec:
   accessModes:

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
@@ -1,0 +1,16 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "ibm-ubiquity-db"
+  annotations:
+    volume.beta.kubernetes.io/storage-class: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
+  labels:
+    pv-name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}   # Ubiquity provisioner will create a PV with dedicated name (by default its ibm-ubiquity-db)
+    product: ibm-storage-enabler-for-containers
+
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-service.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-service.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ubiquity-db
+  labels:
+    app: ubiquity-db
+    product: ibm-storage-enabler-for-containers
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    app: ubiquity-db

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-service.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-service.yml
@@ -2,9 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ubiquity-db
+  namespace: ubiquity
   labels:
     app: ubiquity-db
     product: ibm-storage-enabler-for-containers
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   ports:
     - port: 5432

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
@@ -2,8 +2,13 @@ apiVersion: "extensions/v1beta1"
 kind: Deployment
 metadata:
   name: ubiquity
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: 1
   template:

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
@@ -1,0 +1,169 @@
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: ubiquity
+  labels:
+    product: ibm-storage-enabler-for-containers
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ubiquity
+        product: ibm-storage-enabler-for-containers
+    spec:
+      containers:
+      - name: ubiquity
+        image: {{ .Values.images.ubiquity }}
+        ports:
+        - containerPort: 9999
+          name: ubiquity-port
+        env:
+          ### Spectrum Connect(previously known as SCBE) connectivity parameters:
+          #############################################
+          - name: SCBE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: username
+
+          - name: SCBE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: password
+
+          - name: SCBE_SSL_MODE            # Values : require/verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+          - name: SCBE_MANAGEMENT_IP
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SCBE-MANAGEMENT-IP
+
+          - name: SCBE_MANAGEMENT_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SCBE-MANAGEMENT-PORT
+
+
+
+          ### Ubiquity Spectrum Connect(previously known as SCBE) backend parameters:
+          #####################################
+          - name: SCBE_DEFAULT_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SCBE-DEFAULT-SERVICE
+
+          - name: DEFAULT_VOLUME_SIZE
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: DEFAULT-VOLUME-SIZE
+
+          - name: UBIQUITY_INSTANCE_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: UBIQUITY-INSTANCE-NAME
+
+          - name: DEFAULT_FSTYPE    # ext4 or xfs
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: DEFAULT-FSTYPE
+
+          - name: IBM_UBIQUITY_DB_PV_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: IBM-UBIQUITY-DB-PV-NAME
+
+
+
+          ### Ubiquity generic parameters:
+          ################################
+          - name: LOG_LEVEL         # debug / info / error
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: LOG-LEVEL
+
+          - name: PORT              # Ubiquity port
+            value: "9999"
+          - name: LOG_PATH          # Ubiquity log file directory
+            value: "/tmp"
+          - name: DEFAULT_BACKEND   # "IBM Storage Enabler for Containers" supports "scbe" (Spectrum Connect) as its backend.
+            value: "scbe"
+
+
+
+          ### Ubiquity DB parameters:
+          ###########################
+          - name: UBIQUITY_DB_PSQL_HOST   # Ubiquity DB hostname, should point to the ubiquity-db service name
+            value: "ubiquity-db"
+          - name: UBIQUITY_DB_PSQL_PORT   # Ubiquity DB port, should point to the ubiquity-db port
+            value: "5432"
+          - name: UBIQUITY_DB_CONNECT_TIMEOUT
+            value: "3"
+
+          - name: UBIQUITY_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: username
+
+          - name: UBIQUITY_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: password
+
+          - name: UBIQUITY_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ubiquity-db-credentials
+                key: dbname
+
+          - name: UBIQUITY_DB_SSL_MODE         # Values : require/verify-full. The default is disable # TODO verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+        volumeMounts:
+        - name: ubiquity-private-certificate
+          mountPath: /var/lib/ubiquity/ssl/private
+          readOnly: true
+        - name: ubiquity-public-certificates
+          mountPath: /var/lib/ubiquity/ssl/public
+          readOnly: true
+
+      volumes:
+      - name: ubiquity-private-certificate
+        secret:
+          secretName: ubiquity-private-certificate
+          items:
+          - key: ubiquity.crt
+            path: ubiquity.crt
+            mode: 0600
+          - key: ubiquity.key
+            path: ubiquity.key
+            mode: 0600
+      - name: ubiquity-public-certificates
+        configMap:
+          name: ubiquity-public-certificates
+          items:
+          - key: ubiquity-db-trusted-ca.crt
+            path: ubiquity-db-trusted-ca.crt
+          - key: scbe-trusted-ca.crt
+            path: scbe-trusted-ca.crt
+{{ end }}
+

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
@@ -1,0 +1,113 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: ubiquity-k8s-flex
+  labels:
+    app: ubiquity-k8s-flex
+    product: ibm-storage-enabler-for-containers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ubiquity-k8s-flex
+        product: ibm-storage-enabler-for-containers
+    spec:
+      tolerations:   # Create flex Pods also on master nodes (even if there are NoScheduled nodes)
+      # Some k8s versions use dedicated key for toleration of the master and some use node-role.kubernetes.io/master key.
+      - key: dedicated
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: ubiquity-k8s-flex
+        image: {{ .Values.images.flex }}
+        env:
+          - name: UBIQUITY_PORT     # Ubiquity port, should point to the ubiquity service port
+            value: "9999"
+
+          - name: UBIQUITY_BACKEND         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
+            value: "scbe"
+
+          - name: FLEX_LOG_DIR    # /var/log default
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: FLEX-LOG-DIR
+
+          - name: FLEX_LOG_ROTATE_MAXSIZE # 50MB default
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: FLEX-LOG-ROTATE-MAXSIZE
+
+          - name: LOG_LEVEL       # debug / info / error
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: LOG-LEVEL
+
+          - name: UBIQUITY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: username
+
+          - name: UBIQUITY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: password
+
+          - name: UBIQUITY_PLUGIN_SSL_MODE   # require / verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+          - name: UBIQUITY_IP_ADDRESS   # The ubiquity service IP. The flex pod will update this IP inside the flex config file
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: UBIQUITY-IP-ADDRESS
+
+          - name: SKIP_RESCAN_ISCSI       # boolean
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SKIP-RESCAN-ISCSI
+
+
+
+        command: ["./setup_flex.sh"]
+        volumeMounts:
+        - name: host-k8splugindir
+          mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+
+        - name: flex-log-dir
+          mountPath: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+        - name: ubiquity-public-certificates
+          mountPath: /var/lib/ubiquity/ssl/public
+          readOnly: true
+{{ end }}
+      volumes:
+      - name: host-k8splugindir
+        hostPath:
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec  # This directory must exist on the host
+
+      - name: flex-log-dir
+        hostPath:
+          path: {{ .Values.genericConfig.logging.flexLogDir | quote  }}  # This directory must exist on the host
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+      - name: ubiquity-public-certificates
+        configMap:
+          name: ubiquity-public-certificates
+          items:
+            - key: ubiquity-trusted-ca.crt
+              path: ubiquity-trusted-ca.crt
+{{ end }}
+
+#      nodeSelector:    # use this tag to target specific nodes in the cluster for flex installation

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
@@ -2,9 +2,13 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: ubiquity-k8s-flex
+  namespace: ubiquity
   labels:
     app: ubiquity-k8s-flex
     product: ibm-storage-enabler-for-containers
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   updateStrategy:
     type: RollingUpdate

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
@@ -1,0 +1,77 @@
+apiVersion: "extensions/v1beta1"
+kind: Deployment
+metadata:
+  name: ubiquity-k8s-provisioner
+  labels:
+    product: ibm-storage-enabler-for-containers
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ubiquity-k8s-provisioner
+        product: ibm-storage-enabler-for-containers
+    spec:
+      containers:
+      - name: ubiquity-k8s-provisioner
+        image: {{ .Values.images.provisioner }}
+        env:
+          - name: UBIQUITY_ADDRESS  # Ubiquity hostname, should point to the ubiquity service name
+            value: "ubiquity"
+          - name: UBIQUITY_PORT     # Ubiquity port, should point to the ubiquity service port
+            value: "9999"
+          - name: KUBECONFIG
+            value: "/tmp/k8sconfig/config"
+          - name: RETRIES          # number of retries on failure
+            value: "1"
+          - name: LOG_PATH         # provisioner log file directory
+            value: "/tmp"
+          - name: BACKENDS         # "IBM Storage Enabler for Containers" supports "scbe" (IBM Spectrum Connect) as its backend.
+            value: "scbe"
+
+          - name: LOG_LEVEL       # debug / info / error
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: LOG-LEVEL
+
+          - name: UBIQUITY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: username
+
+          - name: UBIQUITY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: scbe-credentials
+                key: password
+
+          - name: UBIQUITY_PLUGIN_SSL_MODE   # require / verify-full
+            valueFrom:
+              configMapKeyRef:
+                name: ubiquity-configmap
+                key: SSL-MODE
+
+        volumeMounts:
+          - name: k8s-config
+            mountPath: /tmp/k8sconfig
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+          - name: ubiquity-public-certificates
+            mountPath: /var/lib/ubiquity/ssl/public
+            readOnly: true
+{{ end }}
+
+      volumes:
+        - name: k8s-config
+          configMap:
+            name: k8s-config
+{{ if and (.Values.spectrumConnect.connectionInfo.sslMode) (eq .Values.spectrumConnect.connectionInfo.sslMode "verify-full") }}
+        - name: ubiquity-public-certificates
+          configMap:
+            name: ubiquity-public-certificates
+            items:
+              - key: ubiquity-trusted-ca.crt
+                path: ubiquity-trusted-ca.crt
+{{ end }}
+

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
@@ -2,8 +2,13 @@ apiVersion: "extensions/v1beta1"
 kind: Deployment
 metadata:
   name: ubiquity-k8s-provisioner
+  namespace: ubiquity
   labels:
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
+    chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: 1
   template:

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-namespace.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-namespace.yml
@@ -1,18 +1,10 @@
 apiVersion: v1
-kind: Service
+kind: Namespace
 metadata:
   name: ubiquity
-  namespace: ubiquity
   labels:
-    app: ubiquity
     product: ibm-storage-enabler-for-containers
+    app: {{ template "ibm_storage_enabler_for_containers.name" . }}
     chart: {{ template "ibm_storage_enabler_for_containers.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-spec:
-  ports:
-    - port: 9999
-      protocol: TCP
-      targetPort: 9999
-  selector:
-    app: ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-service.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-service.yml
@@ -1,0 +1,14 @@
+#apiVersion: v1
+#kind: Service
+#metadata:
+#  name: ubiquity
+#  labels:
+#    app: ubiquity
+#    product: ibm-storage-enabler-for-containers
+#spec:
+#  ports:
+#    - port: 9999
+#      protocol: TCP
+#      targetPort: 9999
+#  selector:
+#    app: ubiquity

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -1,0 +1,75 @@
+# ----------------------------------------------------
+# Helm chart to install IBM storage Enabler for Containers.
+# ----------------------------------------------------
+
+images:
+  ubiquity: ibmcom/ibm-storage-enabler-for-containers:2.0.0
+  ubiquitydb: ibmcom/ibm-storage-enabler-for-containers-db:2.0.0
+  provisioner: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes:2.0.0
+  flex: ibmcom/ibm-storage-flex-volume-for-kubernetes:2.0.0
+
+spectrumConnect:
+  connectionInfo:
+    ## IP\FQDN and port of Spectrum Connect server.
+    fqdn:
+    port:
+
+    ## Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
+    username:
+    password:
+
+    # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
+    sslMode: require
+
+  backendConfig:
+    # A prefix for any new volume created on the storage system.
+    instanceName:
+    # Allowed values: true or false. Set to true if the nodes have FC connectivity.
+    skipRescanIscsi: false
+    # Default Spectrum Connect storage service to be used, if not specified by the storage class.
+    DefaultStorageService:
+
+    newVolumeDefaults:
+      # The fstype of a new volume if not specified by the user in the storage class.
+      # File system type. Allowed values: ext4 or xfs.
+      fsType: ext4
+      # The default volume size (in GB) if not specified by the user when creating a new volume.
+      size: 1
+
+    dbPvConfig:
+      # Ubiquity database PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
+      # For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
+      ubiquityDbPvName: ibm-ubiquity-db
+
+      storageClassForDbPv:
+        # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
+        storageClassName:
+        params:
+          # Storage Class profile parameter should point to the Spectrum Connect storage service name
+          spectrumConnectServiceName:
+          # Storage Class file-system type, Allowed values: ext4 or xfs.
+          fsType: ext4
+
+genericConfig:
+  # The IP address of the ubiquity service object.
+  # The user must update this key manually if the ubiqutiy service object IP was changed.
+  ubiquityIpAddress:
+
+  logging:
+    # Log level. Allowed values: debug, info, error.
+    logLevel: info
+    # Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
+    flexLogDir: /var/log
+
+  ubiquityDbCredentials:
+    # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
+    username:
+    password:
+
+#  k8sApiServerAccess:
+#    # The provisioner will use it to access API server in order to create\delete\view PVCs
+#
+#    # server from the .kube/config
+#    server:
+#    # token from kubectl -n default get secret $(kubectl -n default get secret | grep service-account | awk '{print $1}') -o yaml | grep token: | awk '{print $2}' | base64 -d
+#    token:


### PR DESCRIPTION
Description:
This pull request will address the ubiqutiyIP setting automatically in the helm chart (to remove the limitation of creating ubiqutiy service in advance).
Add a post-install-job.yml to update the ubiquity service ip to k8s flex daemonset.
Add a service-account yml, cluster-role.yaml and cluser-role-binding.yaml for the post-install-job.yml
Add ubiquity-namespace.yml and ubiquity-service.yml.

Here is how to use this new ubiquity helm chart:
======================================
#On the master node do the following:

# Pre requisites before installation

#copy helm chart 
export HOST=<host where you can find the ubiquity-k8s repository>
cd /var/tmp
scp -r $HOST/ubiquity-k8s/helm_chart /var/tmp/
 
#for ubiqutiy provisioner (later will be replaced by service account)
cp ~/.kube/config    /var/tmp/helm_chart/ibm_storage_enabler_for_containers

# Installation phase:
#-----------------------------

helm install ./ibm_storage_enabler_for_containers -f ./ibm_storage_enabler_for_containers/myvalues.yaml  --name ubiquity 
#NOTE: it will take 2 minutes because the provision stuck first due to ubiqutiy service is not up yet.  So to avoid waiting, one can just kill the provisioner pod so it will start again and succeed.  if needed you can wait just 2 minute and it will go up.
helm ls 
helm status ubiquity
#wait until status is OK and all pods up
