### PR TITLE
Fix/ub 1671 idempotent issues in delete

### DIFF
--- a/volume/provision.go
+++ b/volume/provision.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"k8s.io/api/core/v1"
-	"reflect"
 )
 
 const (

--- a/volume/provision.go
+++ b/volume/provision.go
@@ -193,6 +193,7 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if volume.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimRetain {
 		getVolumeRequest := resources.GetVolumeRequest{Name: volume.Name, Context: requestContext}
 		volume, err := p.ubiquityClient.GetVolume(getVolumeRequest)
+		// if volume not found error return success
 		if err != nil {
 			fmt.Printf("error-retrieving-volume-info")
 			return err

--- a/volume/provision.go
+++ b/volume/provision.go
@@ -194,7 +194,6 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if volume.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimRetain {
 		getVolumeRequest := resources.GetVolumeRequest{Name: volume.Name, Context: requestContext}
 		volume, err := p.ubiquityClient.GetVolume(getVolumeRequest)
-		p.logger.Info(fmt.Sprintf("###Errr : [%s]. error type : [%s]", err, reflect.TypeOf(err)))
 		if err != nil {
 			if strings.Contains(err.Error(), resources.VolumeNotFoundErrorMsg){
 				p.logger.Warning("Idempotent issue while deleting volume : volume was not found in ubiquity DB", logs.Args{{"volume name", volume.Name}})

--- a/volume/provision.go
+++ b/volume/provision.go
@@ -196,11 +196,10 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 		volume, err := p.ubiquityClient.GetVolume(getVolumeRequest)
 		p.logger.Info(fmt.Sprintf("###Errr : [%s]. error type : [%s]", err, reflect.TypeOf(err)))
 		if err != nil {
-			switch err.(type) {
-			case *resources.VolumeNotFoundError:
+			if strings.Contains(err.Error(), resources.VolumeNotFoundErrorMsg){
 				p.logger.Warning("Idempotent issue while deleting volume : volume was not found in ubiquity DB", logs.Args{{"volume name", volume.Name}})
 				return nil
-			default:
+			} else{
 				return p.logger.ErrorRet(err, "error retreiving volume  information.", logs.Args{{"volume name", volume.Name}})
 			}
 		}

--- a/volume/provision.go
+++ b/volume/provision.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	"k8s.io/api/core/v1"
+	"reflect"
 )
 
 const (
@@ -193,6 +194,7 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if volume.Spec.PersistentVolumeReclaimPolicy != v1.PersistentVolumeReclaimRetain {
 		getVolumeRequest := resources.GetVolumeRequest{Name: volume.Name, Context: requestContext}
 		volume, err := p.ubiquityClient.GetVolume(getVolumeRequest)
+		p.logger.Info(fmt.Sprintf("###Errr : [%s]. error type : [%s]", err, reflect.TypeOf(err)))
 		if err != nil {
 			switch err.(type) {
 			case *resources.VolumeNotFoundError:

--- a/volume/provision_test.go
+++ b/volume/provision_test.go
@@ -89,6 +89,15 @@ var _ = Describe("Provisioner", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fakeClient.RemoveVolumeCallCount()).To(Equal(1))
 		})
+		It("succeeds when volume wasnot found in ubiquity DB", func() {
+			fakeClient.GetVolumeReturns(resources.Volume{}, &resources.VolumeNotFoundError{"vol1"})
+			objectMeta := metav1.ObjectMeta{Name: "vol1"}
+			volume := v1.PersistentVolume{ObjectMeta: objectMeta}
+			err = provisioner.Delete(&volume)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeClient.GetVolumeCallCount()).To(Equal(1))
+			Expect(fakeClient.RemoveVolumeCallCount()).To(Equal(0))
+		})
 
 	})
 })


### PR DESCRIPTION
in this PR the idempotent issues in the delete request are fixed.
the issues are as follows: (in delete volume function in the provisioner)

- in get volume  if volume does not exist error is returned then the operation should return success.

comment : an assumption is made that if a volume is removed from the DB then it is definitely removed from the storage since the removal from the DB is the latter operation.

Note: addition PR to handle delete idempotent in the ubiquity server -> https://github.com/IBM/ubiquity/pull/266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/249)
<!-- Reviewable:end -->
