### PR TITLE
Add a cmd to support post-install, pre-delete and sanity

### DIFF
--- a/cmd/hook-executor/logger/logger.go
+++ b/cmd/hook-executor/logger/logger.go
@@ -1,0 +1,36 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+
+	k8sutils "github.com/IBM/ubiquity-k8s/utils"
+)
+
+const (
+	defaultlogPath  = "/var/log"
+	defaultlogLevel = "info"
+)
+
+func init() {
+	initLogger()
+}
+
+func initLogger() {
+	logLevel := os.Getenv("LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = defaultlogLevel
+	}
+	logPath := os.Getenv("LOG_PATH")
+	if logPath == "" {
+		logPath = defaultlogPath
+	}
+
+	err := os.MkdirAll(logPath, 0640)
+	if err != nil {
+		panic(fmt.Errorf("Failed to setup log dir"))
+	}
+
+	//logger := utils.SetupOldLogger(k8sresources.HookExecutorName)
+	k8sutils.InitGenericLogger(logLevel)
+}

--- a/cmd/hook-executor/main.go
+++ b/cmd/hook-executor/main.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	_ "github.com/IBM/ubiquity-k8s/cmd/hook-executor/logger"
+	"github.com/IBM/ubiquity-k8s/helm_chart/hookexecutor"
+
+	flags "github.com/jessevdk/go-flags"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+//PostInstallCommand
+type PostInstallCommand struct {
+	PostInstall func() `short:"i" long:"postinstall" description:"post install"`
+}
+
+func (c *PostInstallCommand) Execute(args []string) error {
+	client := getClientset()
+	return hookexecutor.PostInstallExecutor(client).Execute()
+}
+
+//PreDeleteCommand
+type PreDeleteCommand struct {
+	PreDelete func() `short:"d" long:"predelete" description:"pre delete"`
+}
+
+func (c *PreDeleteCommand) Execute(args []string) error {
+	client := getClientset()
+	return hookexecutor.PreDeleteExecutor(client).Execute()
+}
+
+//SanityCommand
+type SanityCommand struct {
+	Sanity func() `short:"s" long:"sanity" description:"sanity"`
+}
+
+func (c *SanityCommand) Execute(args []string) error {
+	client := getClientset()
+	return hookexecutor.SanityExecutor(client).Execute()
+}
+
+type Options struct{}
+
+func main() {
+	var postInstallCommand PostInstallCommand
+	var preDeleteCommand PreDeleteCommand
+	var sanityCommand SanityCommand
+
+	var options Options
+	var parser = flags.NewParser(&options, flags.Default)
+
+	parser.AddCommand("postinstall",
+		"post install",
+		"post install",
+		&postInstallCommand)
+
+	parser.AddCommand("predelete",
+		"pre delete",
+		"pre delete",
+		&preDeleteCommand)
+
+	parser.AddCommand("sanity",
+		"sanity",
+		"sanity",
+		&sanityCommand)
+
+	_, err := parser.Parse()
+	if err != nil {
+		panic(err)
+		os.Exit(1)
+	}
+}
+
+func getClientset() kubernetes.Interface {
+
+	var config *rest.Config
+
+	//config, err := rest.InClusterConfig()
+	config, err := Config("", "", "ubiquity")
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create k8s InClusterConfig: %v", err))
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create client: %v", err))
+	}
+	return clientset
+}
+
+// config returns a *rest.Config, using either the kubeconfig (if specified)
+// or an in-cluster configuration.
+func Config(kubeconfig, kubecontext, baseName string) (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = kubeconfig
+	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: kubecontext}
+	newConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, configOverrides)
+	clientConfig, err := newConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientConfig.UserAgent = buildUserAgent(
+		baseName,
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+
+	return clientConfig, nil
+}
+
+func buildUserAgent(command, os, arch string) string {
+	return fmt.Sprintf(
+		"%s (%s/%s)", command, os, arch)
+}

--- a/helm_chart/hookexecutor/decoder.go
+++ b/helm_chart/hookexecutor/decoder.go
@@ -1,0 +1,39 @@
+package hookexecutor
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+type Decode func(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error)
+
+type decoder struct {
+	decode Decode
+}
+
+func (d *decoder) FromJson(json []byte) (runtime.Object, error) {
+	return d.From(json)
+}
+
+func (d *decoder) FromYaml(yaml []byte) (runtime.Object, error) {
+	return d.From(yaml)
+}
+
+func (d *decoder) From(data []byte) (runtime.Object, error) {
+	obj, _, err := d.decode(data, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+var KubeDecoder *decoder = &decoder{decode: kubescheme.Codecs.UniversalDeserializer().Decode}
+
+func FromJson(json []byte) (runtime.Object, error) {
+	return KubeDecoder.FromJson(json)
+}
+
+func FromYaml(yaml []byte) (runtime.Object, error) {
+	return KubeDecoder.FromYaml(yaml)
+}

--- a/helm_chart/hookexecutor/interface.go
+++ b/helm_chart/hookexecutor/interface.go
@@ -1,0 +1,31 @@
+package hookexecutor
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+type Executor interface {
+	Execute() error
+}
+
+type baseExcutor struct {
+	kubeClient kubernetes.Interface
+}
+
+func PostInstallExecutor(
+	kubeClient kubernetes.Interface,
+) Executor {
+	return newPostInstallExecutor(kubeClient)
+}
+
+func PreDeleteExecutor(
+	kubeClient kubernetes.Interface,
+) Executor {
+	return newPreDeleteExecutor(kubeClient)
+}
+
+func SanityExecutor(
+	kubeClient kubernetes.Interface,
+) Executor {
+	return newSanityExecutor(kubeClient)
+}

--- a/helm_chart/hookexecutor/post_install.go
+++ b/helm_chart/hookexecutor/post_install.go
@@ -1,0 +1,105 @@
+package hookexecutor
+
+import (
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type postInstallExecutor struct {
+	*baseExcutor
+}
+
+func newPostInstallExecutor(
+	kubeClient kubernetes.Interface,
+) *postInstallExecutor {
+	return &postInstallExecutor{
+		baseExcutor: &baseExcutor{
+			kubeClient: kubeClient,
+		},
+	}
+}
+
+func (e *postInstallExecutor) Execute() error {
+	logger.Info("Performing actions in post-install")
+	err := e.updateFlexDaemonSet()
+	if err != nil {
+		return logger.ErrorRet(err, "Failed performing actions in post-install")
+	} else {
+		logger.Info("Successfully performed actions in post-install")
+		return nil
+	}
+}
+
+func (e *postInstallExecutor) updateFlexDaemonSet() error {
+	ns := getCurrentNamespace()
+	clusterIP, err := e.getUbiquityServiceIP()
+	if err != nil {
+		return logger.ErrorRet(err, fmt.Sprintf("Failed updating DaemonSet %s", ubiquityK8sFlexDaemonSetName))
+	}
+
+	logger.Info(
+		fmt.Sprintf("Updating ubiquity serviceIP to %s in DaemonSet %s in namespace %s",
+			clusterIP,
+			ubiquityK8sFlexDaemonSetName,
+			ns))
+
+	flex, err := e.kubeClient.AppsV1().DaemonSets(ns).Get(ubiquityK8sFlexDaemonSetName, metav1.GetOptions{})
+	if err != nil {
+		return logger.ErrorRet(err, fmt.Sprintf("Failed updating DaemonSet %s", ubiquityK8sFlexDaemonSetName))
+	}
+	containers := flex.Spec.Template.Spec.Containers
+	found := false
+	for i, container := range containers {
+		if container.Name == ubiquityK8sFlexContainerName {
+			envs := containers[i].Env
+			for j, env := range envs {
+				if env.Name == ubiquityIPAddressKey {
+					envs[j].Value = clusterIP
+					found = true
+				}
+			}
+			if !found {
+				ipEnv := corev1.EnvVar{
+					Name:  ubiquityIPAddressKey,
+					Value: clusterIP,
+				}
+				newEnvs := append(envs, ipEnv)
+				containers[i].Env = newEnvs
+			}
+		}
+	}
+
+	_, err = e.kubeClient.AppsV1().DaemonSets(ns).Update(flex)
+	if err != nil {
+		return logger.ErrorRet(err, fmt.Sprintf("Failed updating DaemonSet %s", ubiquityK8sFlexDaemonSetName))
+	}
+	logger.Info(fmt.Sprintf("Successfully updated DaemonSet %s", ubiquityK8sFlexDaemonSetName))
+	return nil
+}
+
+func (e *postInstallExecutor) getUbiquityServiceIP() (string, error) {
+	ns := getCurrentNamespace()
+
+	logger.Info(
+		fmt.Sprintf("Getting ubiquity serviceIP from Service %s in namespace %s",
+			ubiquityServiceName,
+			ns))
+	service, err := e.kubeClient.CoreV1().Services(ns).Get(ubiquityServiceName, metav1.GetOptions{})
+	if err != nil {
+		return "", logger.ErrorRet(err, "Failed getting ubiquity serviceIP")
+	}
+	return service.Spec.ClusterIP, nil
+}
+
+func getCurrentNamespace() string {
+	ns := os.Getenv("NAMESPACE")
+	if ns == "" {
+		return defaultNamespace
+	}
+
+	return ns
+}

--- a/helm_chart/hookexecutor/pre_delete.go
+++ b/helm_chart/hookexecutor/pre_delete.go
@@ -1,0 +1,150 @@
+package hookexecutor
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+type preDeleteExecutor struct {
+	*baseExcutor
+}
+
+func newPreDeleteExecutor(
+	kubeClient kubernetes.Interface,
+) *preDeleteExecutor {
+	return &preDeleteExecutor{
+		baseExcutor: &baseExcutor{
+			kubeClient: kubeClient,
+		},
+	}
+}
+
+func (e *preDeleteExecutor) Execute() error {
+	logger.Info("Performing actions in pre-delete")
+	var err error
+
+	err = e.DeleteUbiquityDBPods()
+	if err != nil {
+		return logger.ErrorRet(err, "Failed performing actions in pre-delete")
+	}
+
+	err = e.DeleteUbiquityDBPvc()
+	if err != nil {
+		return logger.ErrorRet(err, "Failed performing actions in pre-delete")
+	}
+
+	logger.Info("Successfully performed actions in pre-delete")
+	return nil
+}
+
+// DeleteUbiquityDBPods sets replicas of ubiquity-db deployment to 0 and
+// wait for all the relevant pods to be deleted.
+func (e *preDeleteExecutor) DeleteUbiquityDBPods() error {
+	ns := getCurrentNamespace()
+	logger.Info(fmt.Sprintf("Deleting Pods under Ubiquity DB Deployment %s in namespace %s", ubiquityDBDeploymentName, ns))
+
+	deploy, err := e.kubeClient.AppsV1().Deployments(ns).Get(ubiquityDBDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("The Ubiquity DB Deployment is already deleted")
+			return nil
+		}
+		return logger.ErrorRet(err, "Failed deleting Ubiquity DB Pods")
+	}
+
+	var zero = int32(0)
+	deploy.Spec.Replicas = &zero
+	_, err = e.kubeClient.AppsV1().Deployments(ns).Update(deploy)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed deleting Ubiquity DB Pods")
+	}
+	if watchers, err := generatePodsWatchersInDeployment(deploy, e.kubeClient.CoreV1()); err != nil {
+		return logger.ErrorRet(err, "Failed generating Pod watcher")
+	} else {
+		var wg sync.WaitGroup
+		var watcherErr error
+
+		for _, w := range watchers {
+			wg.Add(1)
+			go func() {
+				_, err := Watch(w, nil, 40*time.Second)
+				if err != nil {
+					if watcherErr == nil {
+						watcherErr = err
+					}
+				}
+				wg.Done()
+			}()
+		}
+
+		wg.Wait()
+
+		if watcherErr != nil {
+			return logger.ErrorRet(err, "Failed waiting Pod to be deleted")
+		} else {
+			logger.Info(fmt.Sprintf("Successfully Deleted Pods under Ubiquity DB Deployment %s", ubiquityDBDeploymentName))
+			return nil
+		}
+	}
+}
+
+// DeleteUbiquityDBPvc deletes the ubiquity-db pvc and wait for pvc/pv to be deleted.
+func (e *preDeleteExecutor) DeleteUbiquityDBPvc() error {
+	ns := getCurrentNamespace()
+	logger.Info(fmt.Sprintf("Deleting PVC %s in namespace %s", ubiquityDBPvcName, ns))
+
+	pvc, err := e.kubeClient.CoreV1().PersistentVolumeClaims(ns).Get(ubiquityDBPvcName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info(fmt.Sprintf("The Ubiquity DB PVC %s is already deleted", ubiquityDBPvcName))
+			return nil
+		}
+		return logger.ErrorRet(err, fmt.Sprintf("Failed deleting Ubiquity DB PVC %s", ubiquityDBPvcName))
+	}
+
+	pvcWatcher, err := generatePvcWatcher(pvc.Name, ns, e.kubeClient.CoreV1())
+	if err != nil {
+		return logger.ErrorRet(err, "Failed generating PVC watcher")
+	}
+	pvWatcher, err := generatePvWatcher(pvc.Spec.VolumeName, e.kubeClient.CoreV1())
+	if err != nil {
+		return logger.ErrorRet(err, "Failed generating PV watcher")
+	}
+
+	var wg sync.WaitGroup
+	var watcherErr error
+
+	for _, w := range []watch.Interface{pvcWatcher, pvWatcher} {
+		wg.Add(1)
+		go func() {
+			_, err := Watch(w, nil)
+			if err != nil {
+				if watcherErr == nil {
+					watcherErr = err
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	// start the watcher first and then delete the resource
+	if err := e.kubeClient.CoreV1().PersistentVolumeClaims(ns).Delete(ubiquityDBPvcName, nil); err != nil {
+		return logger.ErrorRet(err, fmt.Sprintf("Failed deleting Ubiquity DB PVC %s", ubiquityDBPvcName))
+	}
+
+	wg.Wait()
+
+	if watcherErr != nil {
+		return logger.ErrorRet(err, "Failed waiting Pod to be deleted")
+	} else {
+		logger.Info(fmt.Sprintf("Successfully Deleted PVC %s", ubiquityDBPvcName))
+		return nil
+	}
+
+}

--- a/helm_chart/hookexecutor/sanity.go
+++ b/helm_chart/hookexecutor/sanity.go
@@ -1,0 +1,173 @@
+package hookexecutor
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+)
+
+type sanityExecutor struct {
+	*baseExcutor
+}
+
+func newSanityExecutor(
+	kubeClient kubernetes.Interface,
+) *sanityExecutor {
+	return &sanityExecutor{
+		baseExcutor: &baseExcutor{
+			kubeClient: kubeClient,
+		},
+	}
+}
+
+func (e *sanityExecutor) Execute() error {
+	logger.Info("Performing actions in sanity test")
+
+	var err error
+	err = e.createSanityResources()
+	if err != nil {
+		return logger.ErrorRet(err, "Failed performing actions in sanity test")
+	}
+
+	err = e.deleteSanityResources()
+	if err != nil {
+		return logger.ErrorRet(err, "Failed performing actions in sanity test")
+	}
+
+	logger.Info("Successfully performed actions in sanity test")
+	return nil
+}
+
+// createSanityResources creates a pvc and a pod and wait utill they reach the desired state.
+func (e *sanityExecutor) createSanityResources() error {
+	logger.Info("Creating sanity resources")
+
+	var err error
+	pvc, pod := getSanityPvcAndPod()
+
+	err = updateStorageClassInPvc(pvc)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed to create sanity resources")
+	}
+
+	logger.Info("Creating sanity PVCs")
+	_, err = e.kubeClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(pvc)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed to create sanity pvcs")
+	}
+
+	pvcWatcher, err := generatePvcWatcher(pvc.Name, pvc.Namespace, e.kubeClient.CoreV1())
+	if err != nil {
+		return logger.ErrorRet(err, "Failed generating PVC watcher")
+	}
+	_, err = Watch(pvcWatcher, func(obj runtime.Object) bool {
+		pvc := obj.(*corev1.PersistentVolumeClaim)
+		return pvc.Status.Phase == corev1.ClaimBound
+	})
+	if err != nil {
+		return logger.ErrorRet(err, "Failed waiting for PVC to be bound")
+	}
+
+	logger.Info("Creating sanity Pods")
+	_, err = e.kubeClient.CoreV1().Pods(pod.Namespace).Create(pod)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed to create sanity pods")
+	}
+
+	podWatcher, err := generatePodWatcher(pod.Name, pod.Namespace, e.kubeClient.CoreV1())
+	if err != nil {
+		return logger.ErrorRet(err, "Failed generating Pod watcher")
+	}
+	_, err = Watch(podWatcher, func(obj runtime.Object) bool {
+		pod := obj.(*corev1.Pod)
+		return pod.Status.Phase == corev1.PodRunning
+	}, 300*time.Second)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed waiting for Pod to be running")
+	}
+
+	logger.Info("Successfully created sanity resources")
+	return nil
+}
+
+// deleteSanityResources deletes the pod and pvc and wait utill they are deleted.
+func (e *sanityExecutor) deleteSanityResources() error {
+	logger.Info("Deleting sanity resources")
+
+	var err error
+	pvc, pod := getSanityPvcAndPod()
+
+	succeeded := make(chan bool)
+
+	go func() {
+		defer close(succeeded)
+
+		podWatcher, _ := generatePodWatcher(pod.Name, pod.Namespace, e.kubeClient.CoreV1())
+		_, err := Watch(podWatcher, nil, 300*time.Second)
+		if err != nil {
+			logger.Error("Failed waiting for Pod to be deleted")
+			succeeded <- false
+		}
+		succeeded <- true
+
+		pvcWatcher, _ := generatePvcWatcher(pvc.Name, pvc.Namespace, e.kubeClient.CoreV1())
+		_, err = Watch(pvcWatcher, nil, 20*time.Second)
+		if err != nil {
+			logger.Error("Failed waiting for PVC to be deleted")
+			succeeded <- false
+		}
+		succeeded <- true
+	}()
+
+	logger.Info("Deleting sanity Pods")
+	err = e.kubeClient.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed to delete sanity pods")
+	}
+
+	done := <-succeeded
+	if !done {
+		return fmt.Errorf("Failed waiting for Pod to be deleted")
+	}
+
+	logger.Info("Deleting sanity PVCs")
+	err = e.kubeClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, nil)
+	if err != nil {
+		return logger.ErrorRet(err, "Failed to delete sanity pvcs")
+	}
+
+	done = <-succeeded
+	if !done {
+		return fmt.Errorf("Failed waiting for PVC to be deleted")
+	}
+
+	logger.Info("Successfully deleted sanity resources")
+	return nil
+}
+
+func getSanityPvcAndPod() (*corev1.PersistentVolumeClaim, *corev1.Pod) {
+	podObj, _ := FromYaml([]byte(sanityPod))
+	pod := podObj.(*corev1.Pod)
+	pvcObj, _ := FromYaml([]byte(sanityPvc))
+	pvc := pvcObj.(*corev1.PersistentVolumeClaim)
+	return pvc, pod
+}
+
+func updateStorageClassInPvc(pvc *corev1.PersistentVolumeClaim) error {
+	sc := os.Getenv("STORAGE_CLASS")
+	if sc == "" {
+		fmt.Errorf("ENV STORAGE_CLASS is not set")
+	}
+
+	annos := pvc.GetAnnotations()
+	if annos == nil {
+		annos = make(map[string]string)
+	}
+	annos["volume.beta.kubernetes.io/storage-class"] = sc
+	pvc.SetAnnotations(annos)
+	return nil
+}

--- a/helm_chart/hookexecutor/sanity_resources.go
+++ b/helm_chart/hookexecutor/sanity_resources.go
@@ -1,0 +1,37 @@
+package hookexecutor
+
+var sanityPod = `
+kind: Pod
+apiVersion: v1
+metadata:
+  name: sanity-pod
+spec:
+  containers:
+  - name: container1
+    image: alpine:latest
+    command: [ "/bin/sh", "-c", "--" ]
+    args: [ "while true; do sleep 30; done;" ]
+    volumeMounts:
+      - name: vol1
+        mountPath: "/data"
+  restartPolicy: "Never"
+  volumes:
+    - name: vol1
+      persistentVolumeClaim:
+        claimName: sanity-pvc
+`
+
+var sanityPvc = `
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: sanity-pvc
+  annotations:
+    volume.beta.kubernetes.io/storage-class: ""
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+`

--- a/helm_chart/hookexecutor/utils.go
+++ b/helm_chart/hookexecutor/utils.go
@@ -1,0 +1,174 @@
+package hookexecutor
+
+import (
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	v1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	api "k8s.io/kubernetes/pkg/apis/core"
+
+	"github.com/IBM/ubiquity/utils/logs"
+)
+
+const (
+	defaultNamespace             = "ubiquity"
+	ubiquityServiceName          = "ubiquity"
+	ubiquityK8sFlexDaemonSetName = "ubiquity-k8s-flex"
+	ubiquityDBDeploymentName     = "ubiquity-db"
+	ubiquityDBPvcName            = "ibm-ubiquity-db"
+	ubiquityK8sFlexContainerName = ubiquityK8sFlexDaemonSetName
+	ubiquityIPAddressKey         = "UBIQUITY_IP_ADDRESS"
+)
+
+var logger = logs.GetLogger()
+
+func match(ls *metav1.LabelSelector, pod *v1.Pod) bool {
+	selector, err := metav1.LabelSelectorAsSelector(ls)
+	if err != nil {
+		return false
+	}
+	return selector.Matches(labels.Set(pod.Labels))
+}
+
+func generatePodsWatchersInDeployment(deploy *appsv1.Deployment, client v1client.PodsGetter) ([]watch.Interface, error) {
+	pods, err := client.Pods(deploy.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		logger.Error("Can't get Pods from API Server")
+		return nil, err
+	}
+	ls := deploy.Spec.Selector
+	watchers := []watch.Interface{}
+
+	for _, pod := range pods.Items {
+		if !match(ls, &pod) {
+			continue
+		}
+
+		logger.Info(fmt.Sprintf("Generating watcher for Pod %s", pod.Name))
+		listOptions := metav1.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(api.ObjectNameField, pod.Name).String(),
+		}
+		watcher, err := client.Pods(deploy.Namespace).Watch(listOptions)
+		if err != nil {
+			logger.Error(fmt.Sprintf("Can't generate watcher for Pod %s", pod.Name))
+			return nil, err
+		} else {
+			logger.Info(fmt.Sprintf("Generated watcher for Pod %s", pod.Name))
+			watchers = append(watchers, watcher)
+		}
+	}
+	return watchers, nil
+}
+
+func generatePodWatcher(name, namespace string, client v1client.PodsGetter) (watch.Interface, error) {
+	logger.Info(fmt.Sprintf("Generating watcher for Pod %s", name))
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(api.ObjectNameField, name).String(),
+	}
+	watcher, err := client.Pods(namespace).Watch(listOptions)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Can't generate watcher for Pod %s", name))
+		return nil, err
+	} else {
+		logger.Info(fmt.Sprintf("Generated watcher for Pod %s", name))
+		return watcher, nil
+	}
+}
+
+func generatePvcWatcher(name, namespace string, client v1client.PersistentVolumeClaimsGetter) (watch.Interface, error) {
+	logger.Info(fmt.Sprintf("Generating watcher for PVC %s", name))
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(api.ObjectNameField, name).String(),
+	}
+	watcher, err := client.PersistentVolumeClaims(namespace).Watch(listOptions)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Can't generate watcher for PVC %s", name))
+		return nil, err
+	} else {
+		logger.Info(fmt.Sprintf("Generated watcher for PVC %s", name))
+		return watcher, nil
+	}
+}
+
+func generatePvWatcher(name string, client v1client.PersistentVolumesGetter) (watch.Interface, error) {
+	logger.Info(fmt.Sprintf("Generating watcher for PV %s", name))
+	listOptions := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(api.ObjectNameField, name).String(),
+	}
+	watcher, err := client.PersistentVolumes().Watch(listOptions)
+	if err != nil {
+		logger.Error(fmt.Sprintf("Can't generate watcher for PV %s", name))
+		return nil, err
+	} else {
+		logger.Info(fmt.Sprintf("Generated watcher for PV %s", name))
+		return watcher, nil
+	}
+}
+
+// desiredStateChecker: check if the resource meet the desired state, if it is nil,
+// means that the caller expects the resource to be deleted.
+func Watch(watcher watch.Interface, desiredStateChecker func(runtime.Object) bool, timeout ...time.Duration) (bool, error) {
+	var err error
+
+	t := 30 * time.Second
+	if len(timeout) > 0 {
+		t = timeout[0]
+	}
+	timer := time.NewTimer(t)
+
+	logger.Info("Start watching resource")
+
+outerLoop:
+	for {
+		select {
+		case event := <-watcher.ResultChan():
+			if event.Type == watch.Modified {
+				//var metadata metav1.Object
+				metadata, err := meta.Accessor(event.Object)
+				if err != nil {
+					logger.Error("Can not get resource metadata")
+				} else {
+					if metadata.GetDeletionTimestamp() != nil {
+						logger.Info("The resource is terminating")
+						if desiredStateChecker != nil {
+							// the resource is terminating, it can not reach the desired state any more.
+							break outerLoop
+						}
+					}
+				}
+
+				if desiredStateChecker != nil {
+					if desiredStateChecker(event.Object) {
+						logger.Info("The resource reaches the desired state.")
+						break outerLoop
+					}
+
+				}
+			}
+			if event.Type == watch.Deleted {
+				logger.Info("The resource is deleted.")
+				break outerLoop
+			}
+		case <-timer.C:
+			err = fmt.Errorf("Timed out waiting for new job changes")
+			logger.Error(err.Error())
+			break outerLoop
+		}
+	}
+	// stop watching this resource
+	watcher.Stop()
+	logger.Info("Stop watching resource")
+	if err != nil {
+		return false, err
+	} else {
+		return true, nil
+	}
+}

--- a/scripts/build_hook_executor
+++ b/scripts/build_hook_executor
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+scripts=$(dirname $0)
+
+echo "Building hook executor"
+go build -o $scripts/../bin/hook-executor $scripts/../cmd/hook-executor/main.go

--- a/utils/logger_utils.go
+++ b/utils/logger_utils.go
@@ -1,21 +1,25 @@
 package utils
 
 import (
-	"github.com/IBM/ubiquity/utils/logs"
+	"path"
+
 	k8sresources "github.com/IBM/ubiquity-k8s/resources"
 	"github.com/IBM/ubiquity/resources"
-	"path"
+	"github.com/IBM/ubiquity/utils/logs"
 )
 
-func InitFlexLogger(config resources.UbiquityPluginConfig) func(){
-	var logger_params = logs.LoggerParams{ShowGoid: false, ShowPid : true}
-	deferFunction :=  logs.InitFileLogger(logs.GetLogLevelFromString(config.LogLevel), path.Join(config.LogPath, k8sresources.UbiquityFlexLogFileName), config.LogRotateMaxSize, logger_params)
+func InitFlexLogger(config resources.UbiquityPluginConfig) func() {
+	var logger_params = logs.LoggerParams{ShowGoid: false, ShowPid: true}
+	deferFunction := logs.InitFileLogger(logs.GetLogLevelFromString(config.LogLevel), path.Join(config.LogPath, k8sresources.UbiquityFlexLogFileName), config.LogRotateMaxSize, logger_params)
 	return deferFunction
 }
 
-func InitProvisionerLogger(ubiquityConfig resources.UbiquityPluginConfig) func(){
-	deferFunction :=  logs.InitStdoutLogger(logs.GetLogLevelFromString(ubiquityConfig.LogLevel), logs.LoggerParams{ShowGoid: false, ShowPid : false})
+func InitProvisionerLogger(ubiquityConfig resources.UbiquityPluginConfig) func() {
+	deferFunction := logs.InitStdoutLogger(logs.GetLogLevelFromString(ubiquityConfig.LogLevel), logs.LoggerParams{ShowGoid: false, ShowPid: false})
 	return deferFunction
 }
 
-
+func InitGenericLogger(logLevel string) func() {
+	deferFunction := logs.InitStdoutLogger(logs.GetLogLevelFromString(logLevel), logs.LoggerParams{ShowGoid: false, ShowPid: false})
+	return deferFunction
+}


### PR DESCRIPTION
first drop for image for helm chart, adding a new cmd "hook-executor"
```
Usage:
  hook-executor [OPTIONS] <postinstall | predelete | sanity>

Available commands:
  postinstall  post install
  predelete    pre delete
  sanity       sanity
```
For details:
1. "hook-executor postinstall" should be called after all the templates in the chart are created, it will get the ubiquity Service IP and update it to the flex DaemenSet.
2. "hook-executor predelete" should be called before the deletion of any resources, it will set the ubiquity DB Deployment's replicas to 0, and wait utill all the Pods are deleted, and then delete the DB PVC, wait utill the PVC and PV are deleted.
3. "hook-executor sanity" should be called by a "helm test" cmd, it will create a Pod and a PVC, wait utill PVC is bound and Pod is running, and then delete the Pod and PVC, wait utill they are deleted.
