### PR TITLE
Improvement/values.yml new layout - to align helm guidelines

### DIFF
--- a/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/scbe-credentials-secret.yml
@@ -1,4 +1,4 @@
-{{- if .Values.spectrumConnect }}
+{{- if .Values.ubiquity.spectrumConnect }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,8 +9,8 @@ metadata:
 type: Opaque
 data:
    # Base64-encoded username defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
-   username: {{ .Values.spectrumConnect.connectionInfo.username | b64enc | quote  }}
+   username: {{ .Values.ubiquity.spectrumConnect.connectionInfo.username | b64enc | quote  }}
 
    # Base64-encoded password defined for the IBM Storage Enabler for Containers interface in Spectrum Connect.
-   password: {{ .Values.spectrumConnect.connectionInfo.password | b64enc | quote }}
+   password: {{ .Values.ubiquity.spectrumConnect.connectionInfo.password | b64enc | quote }}
 {{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/spectrumscale-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/spectrumscale-credentials-secret.yml
@@ -1,4 +1,4 @@
-{{- if .Values.spectrumScale }}
+{{- if .Values.ubiquity.spectrumScale }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,8 +9,8 @@ metadata:
 type: Opaque
 data:
    # Base64-encoded username defined for Spectrum Scale system
-   username: {{ .Values.spectrumScale.connectionInfo.username | b64enc | quote  }}
+   username: {{ .Values.ubiquity.spectrumScale.connectionInfo.username | b64enc | quote  }}
 
    # Base64-encoded password defined for Spectrum Scale system
-   password: {{ .Values.spectrumScale.connectionInfo.password | b64enc | quote }}
+   password: {{ .Values.ubiquity.spectrumScale.connectionInfo.password | b64enc | quote }}
 {{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class-spectrumscale.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class-spectrumscale.yml
@@ -1,18 +1,18 @@
-{{- if .Values.spectrumScale }}
+{{- if .Values.ubiquityDb.persistence.storageClass.spectrumScale }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: {{ .Values.spectrumScale.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName | quote }}
+  name: {{ .Values.ubiquityDb.persistence.storageClass.storageClassName | quote }}
   labels:
     product: ibm-storage-enabler-for-containers
-{{- if .Values.spectrumScale.backendConfig.dbPvConfig.storageClassForDbPv.defaultClass }}
+{{- if .Values.ubiquityDb.persistence.storageClass.defaultClass }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 provisioner: "ubiquity/flex"
 parameters:
   backend: "spectrum-scale"
-  filesystem: {{ .Values.spectrumScale.backendConfig.defaultFilesystemName | quote }}
-  fileset-type: "dependent"
+  filesystem: {{ .Values.ubiquity.spectrumScale.backendConfig.defaultFilesystemName | quote }}
+  fileset-type: "dependent"   ## Not allow to change it via the values.yml file, because for the DB volume the storage class must be dependent.
   type: fileset
 {{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/storage-class.yml
@@ -1,17 +1,17 @@
-{{- if .Values.spectrumConnect }}
+{{- if .Values.ubiquity.spectrumConnect }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1
 metadata:
-  name: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName  | quote }}
+  name: {{ .Values.ubiquityDb.persistence.storageClass.storageClassName  | quote }}
   labels:
     product: ibm-storage-enabler-for-containers
-{{- if .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.defaultClass }}
+{{- if .Values.ubiquityDb.persistence.storageClass.defaultClass }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 provisioner: "ubiquity/flex"
 parameters:
-  profile: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.params.spectrumConnectServiceName  | quote }}
-  fstype: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.params.fsType  | quote }}        # xfs or ext4
+  profile: {{ .Values.ubiquityDb.persistence.storageClass.spectrumConnect.spectrumConnectServiceName  | quote }}
+  fstype: {{ .Values.ubiquityDb.persistence.storageClass.spectrumConnect.fsType  | quote }}        # xfs or ext4
   backend: "scbe"
 {{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-configmap.yml
@@ -8,70 +8,67 @@ metadata:
 data:
    # The keys below are used by ubiquity deployment
    # -----------------------------------------------
-{{- if .Values.spectrumConnect }}
+{{- if .Values.ubiquity.spectrumConnect }}
    # IP or FQDN of Spectrum Connect(previously known as SCBE) server.
-   SCBE-MANAGEMENT-IP: {{ .Values.spectrumConnect.connectionInfo.fqdn | quote }}
+   SCBE-MANAGEMENT-IP: {{ .Values.ubiquity.spectrumConnect.connectionInfo.fqdn | quote }}
 
    # Communication port of Spectrum Connect server. Optional parameter with default value set at 8440.
-   SCBE-MANAGEMENT-PORT: {{ .Values.spectrumConnect.connectionInfo.port | quote }}
+   SCBE-MANAGEMENT-PORT: {{ .Values.ubiquity.spectrumConnect.connectionInfo.port | quote }}
 
    # Default Spectrum Connect storage service to be used, if not specified by the plugin.
-   SCBE-DEFAULT-SERVICE: {{ .Values.spectrumConnect.backendConfig.DefaultStorageService | quote }}
+   SCBE-DEFAULT-SERVICE: {{ .Values.ubiquity.spectrumConnect.backendConfig.DefaultStorageService | quote }}
 
    # The size for a new volume if not specified by the user when creating a new volume. Optional parameter with default value set at 1GB.
-   DEFAULT-VOLUME-SIZE: {{ .Values.spectrumConnect.backendConfig.newVolumeDefaults.size | quote }}
+   DEFAULT-VOLUME-SIZE: {{ .Values.ubiquity.spectrumConnect.backendConfig.newVolumeDefaults.size | quote }}
 
    # A prefix for any new volume created on the storage system. Default value is None.
-   UBIQUITY-INSTANCE-NAME: {{ .Values.spectrumConnect.backendConfig.instanceName | quote }}
+   UBIQUITY-INSTANCE-NAME: {{ .Values.ubiquity.spectrumConnect.backendConfig.instanceName | quote }}
 
    # File system type. Optional parameter with two allowed values: ext4 or xfs. Default value is ext4.
-   DEFAULT-FSTYPE: {{ .Values.spectrumConnect.backendConfig.newVolumeDefaults.fsType | quote }}
+   DEFAULT-FSTYPE: {{ .Values.ubiquity.spectrumConnect.backendConfig.newVolumeDefaults.fsType | quote }}
 
    # Default Ubiquity Backend
    DEFAULT-BACKEND: scbe
-
-   # DB pv name.
-   IBM-UBIQUITY-DB-PV-NAME: {{ .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}
 {{- end }}
 
 
 
-{{- if .Values.spectrumScale }}
+{{- if .Values.ubiquity.spectrumScale }}
    # IP or FQDN of Spectrum Scale Management API server(GUI).
-   SPECTRUMSCALE-MANAGEMENT-IP: {{ .Values.spectrumScale.connectionInfo.fqdn | quote }}
+   SPECTRUMSCALE-MANAGEMENT-IP: {{ .Values.ubiquity.spectrumScale.connectionInfo.fqdn | quote }}
   
    # Communication port of Spectrum Scale Management API server(GUI).
-   SPECTRUMSCALE-MANAGEMENT-PORT: {{ .Values.spectrumScale.connectionInfo.port | quote }}
+   SPECTRUMSCALE-MANAGEMENT-PORT: {{ .Values.ubiquity.spectrumScale.connectionInfo.port | quote }}
 
    # Default Filesystem for creating pvc
-   SPECTRUMSCALE-DEFAULT-FILESYSTEM-NAME: {{ .Values.spectrumScale.backendConfig.defaultFilesystemName | quote }}
+   SPECTRUMSCALE-DEFAULT-FILESYSTEM-NAME: {{ .Values.ubiquity.spectrumScale.backendConfig.defaultFilesystemName | quote }}
 
    # Default Ubiquity Backend
    DEFAULT-BACKEND: spectrum-scale
+{{- end }}
 
    # DB pv name.
-   IBM-UBIQUITY-DB-PV-NAME: {{ .Values.spectrumScale.backendConfig.dbPvConfig.ubiquityDbPvName | quote }}
-{{- end }}
+   IBM-UBIQUITY-DB-PV-NAME: {{ .Values.ubiquityDb.persistence.pvName | quote }}
 
 
 
    # The following keys are used by ubiquity, ubiquity-k8s-provisioner deployments, And ubiquity-k8s-flex daemon-set
    # ----------------------------------------------------------------------------------------------------------------------------
    # Flex log path. Allow to configure it, just make sure the the new path exist on all the minons and update the hostpath in the Flex daemonset
-   FLEX-LOG-DIR: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
+   FLEX-LOG-DIR: {{ .Values.ubiquityK8sFlex.flexLogDir | quote  }}
 
    # Maxlog size(MB) for rotate
    FLEX-LOG-ROTATE-MAXSIZE: "50"
 
    # Log level. Allowed values: debug, info, error.
-   LOG-LEVEL: {{ .Values.genericConfig.logging.logLevel  | quote }}
+   LOG-LEVEL: {{ .Values.globalConfig.logLevel | quote }}
 
 
    # The following keys are used by the ubiquity-k8s-flex daemonset
    # --------------------------------------------------------------
    # The IP address of the ubiquity service object. The ubiquity_installer.sh automatically updates this field during the initial installation.
    # The user must update this key manually if the ubiqutiy service object IP was changed.
-   UBIQUITY-IP-ADDRESS: {{ .Values.genericConfig.ubiquityIpAddress | quote }}  # TODO this should be automatically set by post hook script(different PR)
+   UBIQUITY-IP-ADDRESS: {{ .Values.ubiquityK8sFlex.ubiquityIpAddress | quote }}  # TODO this should be automatically set by post hook script(different PR)
 
    # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
-   SSL-MODE: {{ .Values.genericConfig.connectionInfo.sslMode | quote }}
+   SSL-MODE: {{ .Values.globalConfig.sslMode | quote }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-credentials-secret.yml
@@ -11,10 +11,10 @@ metadata:
 type: Opaque
 data:
    # Base64-encoded username to be set for the ubiquity-db deployment.
-   username: {{ .Values.genericConfig.ubiquityDbCredentials.username | b64enc | quote }}
+   username: {{ .Values.ubiquityDb.dbCredentials.username | b64enc | quote }}
 
    # Base64-encoded password to be set for the ubiquity-db deployment.
-   password: {{ .Values.genericConfig.ubiquityDbCredentials.password | b64enc | quote }}
+   password: {{ .Values.ubiquityDb.dbCredentials.password | b64enc | quote }}
 
    # Base64-encoded database name ("dWJpcXVpdHk=" base64 is "ubiquity") to be created for the ubiquity-db deployment.
    dbname: "dWJpcXVpdHk="

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
@@ -12,13 +12,18 @@ spec:
         app: ubiquity-db
         product: ibm-storage-enabler-for-containers
     spec:
-      {{- if .Values.genericConfig.ubiquityDbNodeSelector }}
+      {{- if .Values.ubiquityDb.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.ubiquityDbNodeSelector | indent 8}}
+{{ toYaml .Values.ubiquityDb.nodeSelector | indent 8}}
       {{- end }}
       containers:
       - name: ubiquity-db
-        image: {{ .Values.images.ubiquitydb }}
+        image: "{{ .Values.ubiquityDb.image.repository }}:{{ .Values.ubiquityDb.image.tag }}"
+        imagePullPolicy: {{ .Values.ubiquityDb.image.pullPolicy }}
+        {{- with .Values.ubiquityDb.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         ports:
         - containerPort: 5432
           name: ubiq-db-port  # no more then 15 chars
@@ -45,7 +50,7 @@ spec:
           - name: ibm-ubiquity-db
             mountPath: "/var/lib/postgresql/data"
             subPath: "ibm-ubiquity"
-{{- if eq .Values.genericConfig.connectionInfo.sslMode "verify-full" }}
+{{- if eq .Values.globalConfig.sslMode "verify-full" }}
           - name: ubiquity-db-private-certificate
             mountPath: /var/lib/postgresql/ssl/private/
 {{- end }}
@@ -54,7 +59,7 @@ spec:
       - name: ibm-ubiquity-db
         persistentVolumeClaim:
           claimName: ibm-ubiquity-db
-{{- if (eq .Values.genericConfig.connectionInfo.sslMode "verify-full") }}
+{{- if (eq .Values.globalConfig.sslMode "verify-full") }}
       - name: ubiquity-db-private-certificate
         secret:
           secretName: ubiquity-db-private-certificate

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
@@ -4,21 +4,13 @@ metadata:
   name: "ibm-ubiquity-db"
   labels:
     # Ubiquity provisioner will create a PV with dedicated name (by default its ibm-ubiquity-db)
-    pv-name: {{ if (.Values.spectrumConnect) }}
- {{- .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName | quote -}}
-{{- else if (.Values.spectrumScale) }}
- {{- .Values.spectrumScale.backendConfig.dbPvConfig.ubiquityDbPvName -}}
-{{- end }}
+    pv-name: {{ .Values.ubiquityDb.persistence.pvName | quote }}
     product: ibm-storage-enabler-for-containers
 
 spec:
-  storageClassName: {{ if (.Values.spectrumConnect) }}
- {{- .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName | quote -}}
-{{- else if (.Values.spectrumScale) }}
- {{- .Values.spectrumScale.backendConfig.dbPvConfig.storageClassForDbPv.storageClassName | quote -}}
-{{- end }}
+  storageClassName: {{ .Values.ubiquityDb.persistence.storageClass.storageClassName | quote }}
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: {{ .Values.ubiquityDb.persistence.pvSize | quote  }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-deployment.yml
@@ -14,12 +14,17 @@ spec:
     spec:
       containers:
       - name: ubiquity
-        image: {{ .Values.images.ubiquity }}
+        image: "{{ .Values.ubiquity.image.repository }}:{{ .Values.ubiquity.image.tag }}"
+        imagePullPolicy: {{ .Values.ubiquity.image.pullPolicy }}
         ports:
         - containerPort: 9999
           name: ubiquity-port
+        {{- with .Values.ubiquity.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         env:
-{{- if .Values.spectrumConnect }}
+{{- if .Values.ubiquity.spectrumConnect }}
           ### Spectrum Connect(previously known as SCBE) connectivity parameters:
           #############################################
           - name: SCBE_USERNAME
@@ -82,7 +87,7 @@ spec:
 {{- end }}
 
 
-{{- if .Values.spectrumScale }}
+{{- if .Values.ubiquity.spectrumScale }}
 
           ### Ubiquity Spectrum Scale backend parameters:
           #####################################
@@ -184,7 +189,7 @@ spec:
                 name: ubiquity-configmap
                 key: SSL-MODE
 
-{{- if (eq .Values.genericConfig.connectionInfo.sslMode "verify-full") }}
+{{- if (eq .Values.globalConfig.sslMode "verify-full") }}
         volumeMounts:
         - name: ubiquity-private-certificate
           mountPath: /var/lib/ubiquity/ssl/private
@@ -210,11 +215,11 @@ spec:
           items:
           - key: ubiquity-db-trusted-ca.crt
             path: ubiquity-db-trusted-ca.crt
-  {{- if .Values.spectrumConnect }}
+  {{- if .Values.ubiquity.spectrumConnect }}
           - key: scbe-trusted-ca.crt
             path: scbe-trusted-ca.crt
   {{- end }}
-  {{- if .Values.spectrumScale }}
+  {{- if .Values.ubiquity.spectrumScale }}
           - key: spectrumscale-trusted-ca.crt
             path: spectrumscale-trusted-ca.crt
   {{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-flex-daemonset.yml
@@ -15,8 +15,8 @@ spec:
         product: ibm-storage-enabler-for-containers
     spec:
       tolerations:   # Create flex Pods also on master nodes (even if there are NoScheduled nodes)
-      {{- if .Values.genericConfig.flexTolerations }}
-{{ toYaml .Values.flexTolerations | indent 6}}
+      {{- if .Values.ubiquityK8sFlex.tolerations }}
+{{ toYaml .Values.ubiquityK8sFlex.tolerations | indent 6}}
       {{- else }}
       # Some k8s versions use dedicated key for toleration of the master and some use node-role.kubernetes.io/master key.
       - key: dedicated
@@ -28,7 +28,13 @@ spec:
 
       containers:
       - name: ubiquity-k8s-flex
-        image: {{ .Values.images.flex }}
+        image: "{{ .Values.ubiquityK8sFlex.image.repository }}:{{ .Values.ubiquityK8sFlex.image.tag }}"
+        imagePullPolicy: {{ .Values.ubiquityK8sFlex.image.pullPolicy }}
+        {{- with .Values.ubiquityK8sFlex.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+
         env:
           - name: UBIQUITY_PORT     # Ubiquity port, should point to the ubiquity service port
             value: "9999"
@@ -54,7 +60,7 @@ spec:
                 name: ubiquity-configmap
                 key: LOG-LEVEL
 
-{{- if .Values.spectrumConnect }}
+{{- if .Values.ubiquity.spectrumConnect }}
           - name: UBIQUITY_USERNAME
             valueFrom:
               secretKeyRef:
@@ -88,8 +94,8 @@ spec:
           mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
 
         - name: flex-log-dir
-          mountPath: {{ .Values.genericConfig.logging.flexLogDir | quote  }}
-{{- if (eq .Values.genericConfig.connectionInfo.sslMode "verify-full") }}
+          mountPath: {{ .Values.ubiquityK8sFlex.flexLogDir | quote  }}
+{{- if (eq .Values.globalConfig.sslMode "verify-full") }}
         - name: ubiquity-public-certificates
           mountPath: /var/lib/ubiquity/ssl/public
           readOnly: true
@@ -101,8 +107,8 @@ spec:
 
       - name: flex-log-dir
         hostPath:
-          path: {{ .Values.genericConfig.logging.flexLogDir | quote  }}  # This directory must exist on the host
-{{- if (eq .Values.genericConfig.connectionInfo.sslMode "verify-full") }}
+          path: {{ .Values.ubiquityK8sFlex.flexLogDir | quote  }}  # This directory must exist on the host
+{{- if (eq .Values.globalConfig.sslMode "verify-full") }}
       - name: ubiquity-public-certificates
         configMap:
           name: ubiquity-public-certificates

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-provisioner-deployment.yml
@@ -15,7 +15,12 @@ spec:
       serviceAccount: ubiquity-k8s-provisioner      # In order to get the server API token from the service account.
       containers:
       - name: ubiquity-k8s-provisioner
-        image: {{ .Values.images.provisioner }}
+        image: "{{ .Values.ubiquityK8sProvisioner.image.repository }}:{{ .Values.ubiquityK8sProvisioner.image.tag }}"
+        imagePullPolicy: {{ .Values.ubiquityK8sProvisioner.image.pullPolicy }}
+        {{- with .Values.ubiquityK8sProvisioner.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+        {{- end }}
         env:
           - name: UBIQUITY_ADDRESS  # Ubiquity hostname, should point to the ubiquity service name
             value: "ubiquity"
@@ -33,7 +38,7 @@ spec:
                 name: ubiquity-configmap
                 key: LOG-LEVEL
 
-{{- if .Values.spectrumConnect }} # TODO consider to check if the secret exist instead
+{{- if .Values.ubiquity.spectrumConnect }} # TODO consider to check if the secret exist instead
           - name: UBIQUITY_USERNAME
             valueFrom:
               secretKeyRef:
@@ -54,7 +59,7 @@ spec:
                 key: SSL-MODE
 
 
-{{- if (eq .Values.genericConfig.connectionInfo.sslMode "verify-full") }}
+{{- if (eq .Values.globalConfig.sslMode "verify-full") }}
         volumeMounts:
           - name: ubiquity-public-certificates
             mountPath: /var/lib/ubiquity/ssl/public

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -1,105 +1,113 @@
-# ----------------------------------------------------
-# Helm chart to install IBM storage Enabler for Containers.
-# ----------------------------------------------------
+# ---------------------------------------------------------
+# Helm chart to install IBM Storage Enabler for Containers.
+# ---------------------------------------------------------
 
-images:
-  ubiquity: ibmcom/ibm-storage-enabler-for-containers:2.0.0
-  ubiquitydb: ibmcom/ibm-storage-enabler-for-containers-db:2.0.0
-  provisioner: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes:2.0.0
-  flex: ibmcom/ibm-storage-flex-volume-for-kubernetes:2.0.0
+ubiquity:
+  image: ibmcom/ibm-storage-enabler-for-containers
+  imageTag: "2.0.0"
+  resources: {}
 
-## IBM Storage Enabler for Containers supports one of the following backend types: spectrumConnect OR spectrumScale.
-## Select a backend that you intend to use and comment out the other backend section.
-spectrumConnect:
-  connectionInfo:
-    ## IP\FQDN and port of Spectrum Connect server.
-    fqdn:
-    port:
+  ## IBM Storage Enabler for Containers supports one of the following backend types: spectrumConnect OR spectrumScale.
+  ## Select a backend that you intend to use and comment out the other backend section.
+  spectrumConnect:
+    connectionInfo:
+      ## IP\FQDN and port of Spectrum Connect server.
+      fqdn:
+      port:
 
-    ## Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
-    username:
-    password:
+      ## Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
+      username:
+      password:
 
-  backendConfig:
-    # A prefix for any new volume created on the storage system.
-    instanceName:
-    # Default Spectrum Connect storage service to be used, if not specified by the storage class.
-    DefaultStorageService:
+    backendConfig:
+      # A prefix for any new volume created on the storage system.
+      instanceName:
+      # Default Spectrum Connect storage service to be used, if not specified by the storage class.
+      DefaultStorageService:
 
-    newVolumeDefaults:
-      # The fstype of a new volume if not specified by the user in the storage class.
-      # File system type. Allowed values: ext4 or xfs.
-      fsType: ext4
-      # The default volume size (in GB) if not specified by the user when creating a new volume.
-      size: 1
+      newVolumeDefaults:
+        # The fstype of a new volume if not specified by the user in the storage class.
+        # File system type. Allowed values: ext4 or xfs.
+        fsType: ext4
+        # The default volume size (in GB) if not specified by the user when creating a new volume.
+        size: 1
 
-    dbPvConfig:
-      # Ubiquity database PV name. For Spectrum Virtualize and Spectrum Accelerate, use default value "ibm-ubiquity-db".
-      # For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
-      ubiquityDbPvName: ibm-ubiquity-db
-
-      storageClassForDbPv:
-        # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
-        # Note: The reclaimPolicy by default is Delete. One can change it manually if needed.
-        storageClassName:
-
-        ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false
-        defaultClass: false
-
-        params:
-          # Storage Class profile parameter should point to the Spectrum Connect storage service name
-          spectrumConnectServiceName:
-          # Storage Class file-system type, Allowed values: ext4 or xfs.
-          fsType: ext4
-
-## IBM storage Enabler for Containers supports two backend types: spectrumConnect OR spectrumScale.
-## Please choose below only one backend and comment-out the other backend section.
-#spectrumScale:
-#  connectionInfo:
-#    # IP\FQDN and port of Spectrum Scale Rest Management API server.
-#    fqdn:
-#    port:
-#
-#    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Scale.
-#    username:
-#    password:
-#
-#  backendConfig:
-#    # Default Spectrum Scale Filesystem to be Used
-#    defaultFilesystemName:
-#
-#    dbPvConfig:
-#      ubiquityDbPvName: ibm-ubiquity-db
-#
-#      storageClassForDbPv:
-#        # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
-#        # Note: The reclaimPolicy by default is Delete. One can change it manually if needed.
-#        storageClassName:
-#
-#        ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false
-#        defaultClass: false
+  ## IBM Storage Enabler for Containers supports one of the following backend types: spectrumConnect OR spectrumScale.
+  ## Select a backend that you intend to use and comment out the other backend section.
+  #spectrumScale:
+  #  connectionInfo:
+  #    # IP\FQDN and port of Spectrum Scale Rest Management API server.
+  #    fqdn:
+  #    port:
+  #
+  #    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Scale.
+  #    username:
+  #    password:
+  #
+  #  backendConfig:
+  #    # Default Spectrum Scale Filesystem to be Used
+  #    defaultFilesystemName:
+  #
 
 
 
-genericConfig:
-  connectionInfo:
-    # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates). SSL mode is for all communications between [flex||provisioner]<->ubiquity<->[SpectrumConnect||SpectrumScale].
-    sslMode: require
-
-  # The IP address of the ubiquity service object.
-  # The user must update this key manually if the ubiqutiy service object IP was changed.
-  ubiquityIpAddress:
-
-  logging:
-    # Log level. Allowed values: debug, info, error.
-    logLevel: info
-    # Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
-    flexLogDir: /var/log
-
+ubiquity-db:
+  image: ibmcom/ibm-storage-enabler-for-containers-db
+  imageTag: "2.0.0"
+  resources: {}
+  NodeSelector: {} # ubiquity-db has presistency, so set the nodeSelector only if needed to control specific nodes with the relevant storageclass connectivity
   ubiquityDbCredentials:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
     username:
     password:
 
-  ## Optional: to set the node selector of the ubiqutiy-db deployment
-  #ubiquityDbNodeSelector:
+  persistency:
+    # Ubiquity database PV name. For Spectrum Virtualize, Spectrum Accelerate and Spectrum Scale, use default value "ibm-ubiquity-db".
+    # For using DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
+    PvName: ibm-ubiquity-db
+
+    storageClass:
+      # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
+      # Note: The reclaimPolicy by default is Delete. One can change it manually if needed.
+      storageClassName:
+
+      ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false
+      defaultClass: false
+
+      ## If ubiquity.SpectrumConnect was set then the following param must set. For spectrum Scale there is no additional param to set.
+      SpectrumConnect:
+        # Storage Class profile parameter should point to the Spectrum Connect storage service name
+        spectrumConnectServiceName:
+        # Storage Class file-system type, Allowed values: ext4 or xfs.
+        fsType: ext4
+
+
+
+ubiquity-k8s-flex:
+  image: ibmcom/ibm-storage-flex-volume-for-kubernetes
+  imageTag: "2.0.0"
+  resources: {}
+  Tolerations: {}
+  # Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
+  flexLogDir: /var/log
+  # The IP address of the ubiquity service object.
+  # The user must update this key manually if the ubiqutiy service object IP was changed.
+  ubiquityIpAddress:
+
+
+ubiquity-k8s-provisioner:
+  image: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes
+  imageTag: "2.0.0"
+  resources: {}
+  ## RBAC is set automatically for the provisioner.
+
+
+genericConfig:
+  # Log level. Allowed values: debug, info, error.
+  logLevel: info
+
+  # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
+  # SSL mode is for all communications between [flex||provisioner]<->ubiquity<->[SpectrumConnect||SpectrumScale].
+  sslMode: require
+
+

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -117,6 +117,7 @@ ubiquity-k8s-provisioner:
   image:
     repository: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes
     tag: "2.0.0"
+    pullPolicy: IfNotPresent
   resources: {}
 
 

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -92,7 +92,7 @@ ubiquityDb:
 
       ## If ubiquity.spectrumScale is set then the following param must set.
       #spectrumScale:
-      #  fileset-type: "dependent"
+      #  fileset-type: "dependent"  #The value of 'fileset-type' parameter must be set to 'dependent'.
 
 
 ubiquityK8sFlex:

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -23,7 +23,7 @@ ubiquity:
     connectionInfo:
       ## IP\FQDN and port of Spectrum Connect server.
       fqdn:
-      port:
+      port: 8440
       ## Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
       username:
       password:
@@ -32,7 +32,7 @@ ubiquity:
       # A prefix for any new volume created on the storage system.
       instanceName:
       # Default Spectrum Connect storage service to be used, if not specified by the storage class.
-      DefaultStorageService:
+      defaultStorageService:
       newVolumeDefaults:
         # The fstype of a new volume if not specified by the user in the storage class.
         # File system type. Allowed values: ext4 or xfs.
@@ -46,7 +46,7 @@ ubiquity:
   #  connectionInfo:
   #    # IP\FQDN and port of Spectrum Scale Rest Management API server.
   #    fqdn:
-  #    port:
+  #    port: 443
   #    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Scale.
   #    username:
   #    password:
@@ -62,7 +62,7 @@ ubiquity-db:
     tag: "2.0.0"
     pullPolicy: IfNotPresent
   resources: {}
-  NodeSelector: {}
+  nodeSelector: {}
   ubiquityDbCredentials:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
     username:
@@ -73,7 +73,7 @@ ubiquity-db:
   persistency:
     # Ubiquity database PV name. For Spectrum Virtualize, Spectrum Accelerate and Spectrum Scale, use default value "ibm-ubiquity-db".
     # For using DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
-    PvName: ibm-ubiquity-db
+    pvName: ibm-ubiquity-db
 
     storageClass:
       # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
@@ -103,7 +103,7 @@ ubiquity-k8s-flex:
   resources: {}
 
   ## By default the toleration set to run the flex Deamonset on all worker and master nodes. To define a different toleration uncomment and apply the relevant toleration.
-  #Tolerations: {}
+  #tolerations: {}
 
   ## Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
   flexLogDir: /var/log

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -1,10 +1,20 @@
 # ---------------------------------------------------------
 # Helm chart to install IBM Storage Enabler for Containers.
+# Enables IBM Storage with Kubernetes by implementing Kubernetes Dynamic Provisioner and FlexVolume.
+#
+# IBM Storage Enabler for Containers includes the following main images:
+#   - deployment/ubiquity
+#   - deployment/ubiquity-db
+#   - deamonset/ubiquity-k8s-flex
+#   - deployment/ubiquity-k8s-provisioner
 # ---------------------------------------------------------
 
+
 ubiquity:
-  image: ibmcom/ibm-storage-enabler-for-containers
-  imageTag: "2.0.0"
+  image:
+    repository: ibmcom/ibm-storage-enabler-for-containers
+    tag: "2.0.0"
+    pullPolicy: IfNotPresent
   resources: {}
 
   ## IBM Storage Enabler for Containers supports one of the following backend types: spectrumConnect OR spectrumScale.
@@ -14,7 +24,6 @@ ubiquity:
       ## IP\FQDN and port of Spectrum Connect server.
       fqdn:
       port:
-
       ## Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Connect.
       username:
       password:
@@ -24,7 +33,6 @@ ubiquity:
       instanceName:
       # Default Spectrum Connect storage service to be used, if not specified by the storage class.
       DefaultStorageService:
-
       newVolumeDefaults:
         # The fstype of a new volume if not specified by the user in the storage class.
         # File system type. Allowed values: ext4 or xfs.
@@ -39,7 +47,6 @@ ubiquity:
   #    # IP\FQDN and port of Spectrum Scale Rest Management API server.
   #    fqdn:
   #    port:
-  #
   #    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Scale.
   #    username:
   #    password:
@@ -47,20 +54,22 @@ ubiquity:
   #  backendConfig:
   #    # Default Spectrum Scale Filesystem to be Used
   #    defaultFilesystemName:
-  #
-
 
 
 ubiquity-db:
-  image: ibmcom/ibm-storage-enabler-for-containers-db
-  imageTag: "2.0.0"
+  image:
+    repository: ibmcom/ibm-storage-enabler-for-containers-db
+    tag: "2.0.0"
+    pullPolicy: IfNotPresent
   resources: {}
-  NodeSelector: {} # ubiquity-db has presistency, so set the nodeSelector only if needed to control specific nodes with the relevant storageclass connectivity
+  NodeSelector: {}
   ubiquityDbCredentials:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
     username:
     password:
 
+  # The Helm installation has automatic boot strap of the ubiqutiy-db volume (PVC named ibm-ubiquity-db).
+  # The boot strap creates a storage class(details below) and the PVC.
   persistency:
     # Ubiquity database PV name. For Spectrum Virtualize, Spectrum Accelerate and Spectrum Scale, use default value "ibm-ubiquity-db".
     # For using DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
@@ -74,32 +83,41 @@ ubiquity-db:
       ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false
       defaultClass: false
 
-      ## If ubiquity.SpectrumConnect was set then the following param must set. For spectrum Scale there is no additional param to set.
-      SpectrumConnect:
+      ## If ubiquity.spectrumConnect was set then the following param must set.
+      spectrumConnect:
         # Storage Class profile parameter should point to the Spectrum Connect storage service name
         spectrumConnectServiceName:
         # Storage Class file-system type, Allowed values: ext4 or xfs.
         fsType: ext4
 
+      ## If ubiquity.spectrumScale was set then the following param must set.
+      #spectrumScale:
+      #  fileset-type: "dependent"
 
 
 ubiquity-k8s-flex:
-  image: ibmcom/ibm-storage-flex-volume-for-kubernetes
-  imageTag: "2.0.0"
+  image:
+    repository: ibmcom/ibm-storage-flex-volume-for-kubernetes
+    tag: "2.0.0"
+    pullPolicy: IfNotPresent
   resources: {}
-  Tolerations: {}
-  # Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
+
+  ## By default the toleration set to run the flex Deamonset on all worker and master nodes. To define a different toleration uncomment and apply the relevant toleration.
+  #Tolerations: {}
+
+  ## Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
   flexLogDir: /var/log
-  # The IP address of the ubiquity service object.
-  # The user must update this key manually if the ubiqutiy service object IP was changed.
+  ## The IP address of the ubiquity service object.
+  ## The user must update this key manually if the ubiqutiy service object IP was changed.
   ubiquityIpAddress:
 
 
 ubiquity-k8s-provisioner:
-  image: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes
-  imageTag: "2.0.0"
+  ## RBAC and service account is set automatically for the provisioner.
+  image:
+    repository: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes
+    tag: "2.0.0"
   resources: {}
-  ## RBAC is set automatically for the provisioner.
 
 
 genericConfig:

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -120,7 +120,7 @@ ubiquity-k8s-provisioner:
   resources: {}
 
 
-genericConfig:
+globalConfig:
   # Log level. Allowed values: debug, info, error.
   logLevel: info
 

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -43,7 +43,7 @@ ubiquity:
   ## Select a backend that you intend to use and comment out the other backend section.
   #spectrumScale:
   #  connectionInfo:
-  #    # IP\FQDN and port of Spectrum Scale Rest Management API server.
+  #    # IP\FQDN and port of Spectrum Scale RESTful API server.
   #    fqdn:
   #    port: 443
   #    # Username and password defined for IBM Storage Enabler for Containers interface in Spectrum Scale.
@@ -51,7 +51,7 @@ ubiquity:
   #    password:
   #
   #  backendConfig:
-  #    # Default Spectrum Scale Filesystem to be Used
+  #    # Default Spectrum Scale filesystem to be used.
   #    defaultFilesystemName:
 
 
@@ -63,34 +63,34 @@ ubiquityDb:
   resources: {}
   nodeSelector: {}
   dbCredentials:
-    # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
+    # Username and password for the deployment of ubiquity-db database. Note: Do not use the "postgres" username, because it already exists.
     username: ubiquity
     password: ubiquity
 
-  # The Helm installation has automatic boot strap of the ubiqutiy-db volume (PVC named ibm-ubiquity-db).
-  # The boot strap creates a storage class(details below) and the PVC.
+  # The Helm installation has automatic boot strap of the ubiquity-db volume (PVC named ibm-ubiquity-db).
+  # The boot strap creates a storage class (see details below) and the PVC.
   persistence:
     # Ubiquity database PV name. For Spectrum Virtualize, Spectrum Accelerate and Spectrum Scale, use default value "ibm-ubiquity-db".
-    # For using DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
+    # For DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
     pvName: ibm-ubiquity-db
     pvSize: 20Gi
 
     storageClass:
-      # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
-      # Note: The reclaimPolicy by default is Delete. One can change it manually if needed.
+      # Parameters to create the first storage class that is also to be used by Ubiquity for ibm-ubiquity-db PVC.
+      # Note: The default reclaimPolicy is Delete. Can be changed manually if needed.
       storageClassName:
 
-      ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false
+      ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false.
       defaultClass: false
 
-      ## If ubiquity.spectrumConnect is set then the following param must set.
+      ## If ubiquity.spectrumConnect is set, the following parameters must be set as well.
       spectrumConnect:
-        # Storage Class profile parameter should point to the Spectrum Connect storage service name
+        # Storage Class profile parameter must point to the Spectrum Connect storage service name.
         spectrumConnectServiceName:
-        # Storage Class file-system type, Allowed values: ext4 or xfs.
+        # Storage Class filesystem type. Allowed values: ext4 or xfs.
         fsType: ext4
 
-      ## If ubiquity.spectrumScale is set then the following param must set.
+      ## If ubiquity.spectrumScale is set, the following parameters must be set as well.
       #spectrumScale:
       #  fileset-type: "dependent"  #The value of 'fileset-type' parameter must be set to 'dependent'.
 
@@ -102,18 +102,18 @@ ubiquityK8sFlex:
     pullPolicy: IfNotPresent
   resources: {}
 
-  ## By default the toleration set to run the flex Deamonset on all worker and master nodes. To define a different toleration uncomment and apply the relevant toleration.
+  ## By default, the toleration is set to run the Flex DeamonSet on all worker and master nodes. To define a different toleration, uncomment and apply the relevant toleration value.
   #tolerations: {}
 
-  ## Flex log directory. If you change the default, then make the new path exist on all the nodes and update the Flex daemonset hostpath according.
+  ## Flex log directory. If the default value is changed, make sure that the new path exists on all the nodes and update the Flex DaemonSet hostpath accordingly.
   flexLogDir: /var/log
   ## The IP address of the ubiquity service object.
-  ## The user must update this key manually if the ubiqutiy service object IP was changed.
+  ## Update this key manually if the ubiquity service object IP was changed.
   ubiquityIpAddress:
 
 
 ubiquityK8sProvisioner:
-  ## RBAC and service account is set automatically for the provisioner.
+  ## RBAC and service account are set automatically for the Provisioner.
   image:
     repository: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes
     tag: "2.0.0"
@@ -126,7 +126,7 @@ globalConfig:
   logLevel: info
 
   # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
-  # SSL mode is for all communications between [flex||provisioner]<->ubiquity<->[SpectrumConnect||SpectrumScale].
+  # SSL mode is set for all communication paths between [flex||provisioner]<->ubiquity<->[SpectrumConnect||SpectrumScale].
   sslMode: require
 
 

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -3,12 +3,11 @@
 # Enables IBM Storage with Kubernetes by implementing Kubernetes Dynamic Provisioner and FlexVolume.
 #
 # IBM Storage Enabler for Containers includes the following main images:
-#   - deployment/ubiquity
-#   - deployment/ubiquity-db
-#   - deamonset/ubiquity-k8s-flex
-#   - deployment/ubiquity-k8s-provisioner
+#   - deployment/ubiquity                 : A mediator between IBM Storage and k8s FlexVolume \ Dynamic Provisioner.
+#   - deployment/ubiquity-db              : Stores meta-data for the dynamic provisioned volumes.
+#   - deamonset/ubiquity-k8s-flex         : Implements k8s FlexVolume driver.
+#   - deployment/ubiquity-k8s-provisioner : Implements k8s Dynamic Provisioner
 # ---------------------------------------------------------
-
 
 ubiquity:
   image:
@@ -56,24 +55,25 @@ ubiquity:
   #    defaultFilesystemName:
 
 
-ubiquity-db:
+ubiquityDb:
   image:
     repository: ibmcom/ibm-storage-enabler-for-containers-db
     tag: "2.0.0"
     pullPolicy: IfNotPresent
   resources: {}
   nodeSelector: {}
-  ubiquityDbCredentials:
+  dbCredentials:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
     username: ubiquity
     password: ubiquity
 
   # The Helm installation has automatic boot strap of the ubiqutiy-db volume (PVC named ibm-ubiquity-db).
   # The boot strap creates a storage class(details below) and the PVC.
-  persistency:
+  persistence:
     # Ubiquity database PV name. For Spectrum Virtualize, Spectrum Accelerate and Spectrum Scale, use default value "ibm-ubiquity-db".
     # For using DS8000 Family, use "ibmdb" instead and make sure UBIQUITY_INSTANCE_NAME_VALUE value length does not exceed 8 chars.
     pvName: ibm-ubiquity-db
+    pvSize: 20Gi
 
     storageClass:
       # Parameters to create the first Storage Class that also be used by ubiquity for ibm-ubiquity-db PVC.
@@ -95,7 +95,7 @@ ubiquity-db:
       #  fileset-type: "dependent"
 
 
-ubiquity-k8s-flex:
+ubiquityK8sFlex:
   image:
     repository: ibmcom/ibm-storage-flex-volume-for-kubernetes
     tag: "2.0.0"
@@ -112,7 +112,7 @@ ubiquity-k8s-flex:
   ubiquityIpAddress:
 
 
-ubiquity-k8s-provisioner:
+ubiquityK8sProvisioner:
   ## RBAC and service account is set automatically for the provisioner.
   image:
     repository: ibmcom/ibm-storage-dynamic-provisioner-for-kubernetes

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -65,8 +65,8 @@ ubiquity-db:
   nodeSelector: {}
   ubiquityDbCredentials:
     # Username and password for the deployment of ubiquity-db database. Note : Do not use the "postgres" username, because it already exists.
-    username:
-    password:
+    username: ubiquity
+    password: ubiquity
 
   # The Helm installation has automatic boot strap of the ubiqutiy-db volume (PVC named ibm-ubiquity-db).
   # The boot strap creates a storage class(details below) and the PVC.
@@ -83,14 +83,14 @@ ubiquity-db:
       ## Set StorageClass as the default StorageClass. Ignored if storageClass.create is false
       defaultClass: false
 
-      ## If ubiquity.spectrumConnect was set then the following param must set.
+      ## If ubiquity.spectrumConnect is set then the following param must set.
       spectrumConnect:
         # Storage Class profile parameter should point to the Spectrum Connect storage service name
         spectrumConnectServiceName:
         # Storage Class file-system type, Allowed values: ext4 or xfs.
         fsType: ext4
 
-      ## If ubiquity.spectrumScale was set then the following param must set.
+      ## If ubiquity.spectrumScale is set then the following param must set.
       #spectrumScale:
       #  fileset-type: "dependent"
 


### PR DESCRIPTION
This PR is for redesign the values.yml layout in order to make it align with helm chart best practices, improve clarity and flexibility.

**Old layout - current state**
The old layout of values.yml had one big configuration keys like spectrumConnect, spectrumScale,  genericConfig and one key for all the images. The original layout is not clear enough and lack of flexability.

_The old layout snippet:_
```
images         - line for every container with its image URL (including the tag and without option to set the pullPolicy)
spectrumConnect or spectrumScale key        - that explain the whole configuration.
genericConfig key       - that define the generic configuration (also covered ubiquitydb name, flexlog dir).
```

**New layout**
The new layout design of values.yml (in this PR) describes all the images of ubiqutiy in a separate key and each docker image has its own configuration. 
pros:
  - Better visibility in the helm chart - user can understand the components in ubiquity.
  - Easier to tube param per container - for example setting the pod resources\tolaration and image settings like repository, tag and pullPolicy.
   - Align with helm chart values file standards.

cons:
   - to update images URL you need to go for each image line and not on the images key in the top of the values.yml file.   (but the new way is more standard so its better)
   - To choose scale you need to choose it on ubiquity container and also on the ubiquity-db where is the persistence. (it make more sense because now the presistance moved to ubiquity-db)

_The layout snippet:_
every docker image has its own key as follow:
```
[component]:
  image:
    repository: [URL]
    tag: [TAG]
    pullPolicy: IfNotPresent
  resources: {}
  [Additional Parameters that related to the image]
```

Notes:
1. [component] could be: ubiquity, ubiquity-db, ubiquity-k8s-provisioner, ubiquity-k8s-flex.
2. Detail about "Additional Parameters" on each image:
    - **ubiquity** includes all the backend configurations (customer need to set Connect or Scale)
    - **ubiquity-db** includes the db credentials and all the presistency - PV\PVC and Storage Class. But also the specific params for the storage class based on the backend type - (customer need to set Connect or Scale).  
    - **ubiquity-k8s-flex** includes the flexLog dir and allow to tune the tolerations (if needed. In some k8s or ICP version the tolaration setting could change, so this will allow to mitigate such change.)
    - **ubiquity-k8s-provisioner** - nothing special
3. In the new layout we also added:
  - Missing default values for port and ubiquity-db credentials.
  - New resources key on each container injected if exist from .Values.[container].resources
  - New pvSize in value yml file for Values.ubiquity-db.persistence.pvSize to allow tune the size instead of hardcode it (its relevant only in the install time).

**New layout - details:**
- .Values.spectrumConnect -> .Values.ubiquity.spectrumConnect   (same for scale)
- .Values.spectrumConnect.backendConfig.dbPvConfig -> ubiquity-db.persistency  (same for scale)
- .Values.genericConfig -> .Values.globalConfig
- choose which storage class to create is based on .Values.ubiquity-db.persistence.storageClass.[spectrumScale || spectrumConnect] and not based on .Values.ubiquity.[spectrumScale || spectrumConnect]

- Moved the pvname and storageClassName from an backend specific setting to be generic, which make it more ready for support scale and block on the same deployment (only 1 storage class for the DB even if u define the 2 backends.).
   - .Values.spectrumConnect.backendConfig.dbPvConfig.ubiquityDbPvName  --> Values.ubiquity-db.persistence.pvName
   - .Values.spectrumConnect.backendConfig.dbPvConfig.storageClassName  --> Values.ubiquity-db.persistence.storageClass.storageClassName


- Moved flex param from genericConfig into the ubiquity-k8s-flex key because its the only contain that uses it:
   -.Values.genericConfig.ubiquityIpAddress -> .Values.ubiquity-k8s-flex.ubiquityIpAddress
   -.Values.genericConfig.logging.flexLogDir -> .Values.ubiquity-k8s-flex.flexLogDir
   -.Values.genericConfig.flexTolerations -> .Values.ubiquity-k8s-flex.tolerations

- Reduced irrelevant level(connectionInfo & logging) in the genericConfig for simplification:
   -.Values.genericConfig.connectionInfo.sslMode ->  .Values.globalConfig.sslMode			reduce connectionInfo level for simplisity
   -.Values.genericConfig.logging.logLevel -> .Values.globalConfig.logLevel				reduce logging level for simplisity

- Moved ubiqutiy-db param from genericConfig into the ubiquity-db key because its the only contain that uses it:
   -.Values.genericConfig.ubiquityDbCredentials ->  .Values.ubiquity-db.dbCredentials
   -.Values.genericConfig.ubiquityDbNodeSelector  -> .Values.ubiquity-db.nodeSelector


- .Values.images.[container] -> "{{.Values.[container].image.repository}}:{{.Values.[container].image.tag}}"
"{{ .Values.ubiquity-k8s-provisioner.image.repository }}:{{ .Values.ubiquity-k8s-provisioner.image.tag }}"




<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/261)
<!-- Reviewable:end -->
