### PR TITLE
avoid checking if symlink for volume already exists for spectrumscale backend

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -769,9 +769,12 @@ func (c *Controller) doMount(mountRequest k8sresources.FlexVolumeMountRequest) (
 		return "", c.logger.ErrorRet(err, "prepareUbiquityMountRequest failed")
 	}
 
-	err = checkSlinkAlreadyExistsOnMountPoint(ubMountRequest.Mountpoint, mountRequest.MountPath, c.logger, c.exec)
-	if err != nil {
-		return "", c.logger.ErrorRet(err, "Failed to check if other links point to mountpoint")
+	if (volumeBackend == resources.SCBE) {
+
+		err = checkSlinkAlreadyExistsOnMountPoint(ubMountRequest.Mountpoint, mountRequest.MountPath, c.logger, c.exec)
+		if err != nil {
+			return "", c.logger.ErrorRet(err, "Failed to check if other links point to mountpoint")
+		}
 	}
 
 	mountpoint, err := mounter.Mount(ubMountRequest)


### PR DESCRIPTION
skip the check for symlink already exist for spectrumscale backend

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/264)
<!-- Reviewable:end -->
