### PR TITLE
Fix/ub 1722 soft link issue on uncleared node

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -688,7 +688,7 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 func checkMountPointIsMounted(mountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
 	defer logger.Trace(logs.INFO, logs.Args{{"mountPoint", mountPoint}})()
 
-	slinkStat, err := executer.Stat(mountPoint)
+	mountPointStat, err := executer.Stat(mountPoint)
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", mountPoint}})
 	}
@@ -699,7 +699,7 @@ func checkMountPointIsMounted(mountPoint string, logger logs.Logger, executer ut
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", mountPoint}})
 	}
 	
-	if executer.GetDeviceForFileStat(slinkStat) != executer.GetDeviceForFileStat(rootDirStat){
+	if executer.GetDeviceForFileStat(mountPointStat) != executer.GetDeviceForFileStat(rootDirStat){
 		return true, nil
 	}	 
 	

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -696,13 +696,13 @@ func checkSlinkIsActuallyInUse(mountPoint string, logger logs.Logger, executer u
 	slinkStat, err := executer.Stat(mountPoint)
 	logger.Info(fmt.Sprintf("slinkStat : %s", slinkStat))
 	if err != nil{
-		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
+		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", mountPoint}})
 	}
 	
 	rootDirStat, err := executer.Lstat(mountPoint + "/..")
 	logger.Info(fmt.Sprintf("rootDirStat : %s", rootDirStat))
 	if err != nil{
-		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
+		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", mountPoint}})
 	}
 	//logger.Info(fmt.Sprintf("slinkStat.Sys() : %s , rootDirStat.Sys() : %s , slinkStat.Sys().(*syscall.Stat_t) : %s , rootDirStat.Sys().(*syscall.Stat_t) : %s ",
 	//slinkStat.Sys(), rootDirStat.Sys(), slinkStat.Sys().(*syscall.Stat_t), rootDirStat.Sys().(*syscall.Stat_t) ))

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -32,7 +32,6 @@ import (
 	"github.com/IBM/ubiquity/utils"
 	"github.com/IBM/ubiquity/utils/logs"
 	"github.com/nightlyone/lockfile"
-	"k8s.io/kubernetes/pkg/util/mount"
 )
  
 const(

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"syscall"
 
 	k8sresources "github.com/IBM/ubiquity-k8s/resources"
 	"github.com/IBM/ubiquity/remote"
@@ -699,8 +698,7 @@ func checkMountPointIsMounted(mountPoint string, logger logs.Logger, executer ut
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", mountPoint}})
 	}
 	
-	// syscal.Stat_t returns the output of a "stat" linux command on the file.
-	if slinkStat.Sys().(*syscall.Stat_t).Dev != rootDirStat.Sys().(*syscall.Stat_t).Dev {
+	if executer.GetDeviceForFileStat(slinkStat) != executer.GetDeviceForFileStat(rootDirStat){
 		return true, nil
 	}	 
 	

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -686,20 +686,20 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 	return tempMountPoint, nil
 }
 
-func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
-	logger.Info(fmt.Sprintf("k8sMountPoint : %s", k8sMountPoint))
-	evaledSimlink, err := executer.EvalSymlinks(k8sMountPoint)
-	logger.Info(fmt.Sprintf("evaed simlink : %s", evaledSimlink))
-	if err != nil {
-		return false, logger.ErrorRet(err, "Failed toedval the symlink.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
-	}
-	slinkStat, err := executer.Stat(evaledSimlink)
+func checkSlinkIsActuallyInUse(mountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
+	logger.Info(fmt.Sprintf("k8sMountPoint : %s", mountPoint))
+//	evaledSimlink, err := executer.EvalSymlinks(k8sMountPoint)
+//	logger.Info(fmt.Sprintf("evaed simlink : %s", evaledSimlink))
+//	if err != nil {
+//		return false, logger.ErrorRet(err, "Failed toedval the symlink.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
+//	}
+	slinkStat, err := executer.Stat(mountPoint)
 	logger.Info(fmt.Sprintf("slinkStat : %s", slinkStat))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
 	}
 	
-	rootDirStat, err := executer.Lstat(evaledSimlink + "/..")
+	rootDirStat, err := executer.Lstat(mountPoint + "/..")
 	logger.Info(fmt.Sprintf("rootDirStat : %s", rootDirStat))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
@@ -760,7 +760,7 @@ func checkSlinkAlreadyExistsOnMountPoint(mountPoint string, k8sMountPoint string
 		
 		isSameFile := executer.IsSameFile(fileStat, mountStat)
 		if isSameFile{
-			isInUse, err := checkSlinkIsActuallyInUse(k8sMountPoint, logger, executer)
+			isInUse, err := checkSlinkIsActuallyInUse(mountPoint, logger, executer)
 			if err != nil {
 				logger.Warning("Failed to check whether slink is in use.", logs.Args{{"file", file}})
 				continue

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -687,7 +687,7 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 }
 
 func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
-	evaledSimlink := executer.EvalSymlinks((k8sMountPoint)
+	evaledSimlink := executer.EvalSymlinks(k8sMountPoint)
 	slinkStat, err := executer.Stat(evaledSimlink)
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -687,20 +687,20 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 }
 
 func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
-	logger.info(fmt.Sprintf("k8sMountPoint : %s", k8sMountPoint))
+	logger.Info(fmt.Sprintf("k8sMountPoint : %s", k8sMountPoint))
 	evaledSimlink, err := executer.EvalSymlinks(k8sMountPoint)
-	logger.info(fmt.Sprintf("evaed simlink : %s", evaledSimlink))
+	logger.Info(fmt.Sprintf("evaed simlink : %s", evaledSimlink))
 	if err != nil {
 		return false, logger.ErrorRet(err, "Failed toedval the symlink.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
 	}
 	slinkStat, err := executer.Stat(evaledSimlink)
-	logger.info(fmt.Sprintf("slinkStat : %s", slinkStat))
+	logger.Info(fmt.Sprintf("slinkStat : %s", slinkStat))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
 	}
 	
 	rootDirStat, err := executer.Lstat(evaledSimlink + "/..")
-	logger.info(fmt.Sprintf("rootDirStat : %s", rootDirStat))
+	logger.Info(fmt.Sprintf("rootDirStat : %s", rootDirStat))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -687,12 +687,13 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 }
 
 func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
-	slinkStat, err := executer.Stat(k8sMountPoint)  // TODO: Lstat?
+	evaledSimlink := executer.EvalSymlinks((k8sMountPoint)
+	slinkStat, err := executer.Stat(evaledSimlink)
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
 	}
 	
-	rootDirStat, err := executer.Lstat(k8sMountPoint + "/..")
+	rootDirStat, err := executer.Lstat(evaledSimlink + "/..")
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -696,6 +696,10 @@ func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, execute
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
 	}
+	logger.Info(fmt.Sprintf("slinkStat.Sys() : %s , rootDirStat.Sys() : %s , slinkStat.Sys().(*syscall.Stat_t) : %s , rootDirStat.Sys().(*syscall.Stat_t) : %s ",
+	slinkStat.Sys(), rootDirStat.Sys(), slinkStat.Sys().(*syscall.Stat_t), rootDirStat.Sys().(*syscall.Stat_t) ))
+	logger.Info(fmt.Sprintf("slinkStat.Sys().(*syscall.Stat_t).Dev : %s  ,    rootDirStat.Sys().(*syscall.Stat_t).Dev : %s", slinkStat.Sys().(*syscall.Stat_t).Dev,rootDirStat.Sys().(*syscall.Stat_t).Dev ))
+	
 	
 	if slinkStat.Sys().(*syscall.Stat_t).Dev != rootDirStat.Sys().(*syscall.Stat_t).Dev {
 		return true, nil
@@ -757,7 +761,7 @@ func checkSlinkAlreadyExistsOnMountPoint(mountPoint string, k8sMountPoint string
 			if isInUse{
 				slinks = append(slinks, file)
 			} else {
-				logger.Warning("found un mounted slink to current mount point", logs.Args{{"file", file}})
+				logger.Warning("found a mounted slink to current mount point - which is not in use.", logs.Args{{"file", file}})
 			}
 			
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"syscall"
 
 	k8sresources "github.com/IBM/ubiquity-k8s/resources"
 	"github.com/IBM/ubiquity/remote"
@@ -693,7 +694,7 @@ func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, execute
 	
 	rootDirStat, err := executer.Lstat(k8sMountPoint + "/..")
 	if err != nil{
-		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", /..}})
+		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
 	}
 	
 	if slinkStat.Sys().(*syscall.Stat_t).Dev != rootDirStat.Sys().(*syscall.Stat_t).Dev {
@@ -748,7 +749,7 @@ func checkSlinkAlreadyExistsOnMountPoint(mountPoint string, k8sMountPoint string
 		
 		isSameFile := executer.IsSameFile(fileStat, mountStat)
 		if isSameFile{
-			isInUse, err := checkSlinkIsActuallyInUse(k8sMountPoint)
+			isInUse, err := checkSlinkIsActuallyInUse(k8sMountPoint, logger, executer)
 			if err != nil {
 				logger.Warning("Failed to check whether slink is in use.", logs.Args{{"file", file}})
 				continue

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -687,7 +687,10 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 }
 
 func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
-	evaledSimlink := executer.EvalSymlinks(k8sMountPoint)
+	evaledSimlink, err := executer.EvalSymlinks(k8sMountPoint)
+	if err != nil {
+		return false, logger.ErrorRet(err, "Failed toedval the symlink.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
+	}
 	slinkStat, err := executer.Stat(evaledSimlink)
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -759,7 +759,7 @@ func checkSlinkAlreadyExistsOnMountPoint(mountPoint string, k8sMountPoint string
 			if isInUse{
 				slinks = append(slinks, file)
 			} else {
-				logger.Warning("found a mounted slink to current mount point - which is not in use.", logs.Args{{"file", file}})
+				logger.Warning("Found a different Pod that uses the same PVC, but the slink is pointing to a directory that is NOT mounted. It may be a stale POD", logs.Args{{"pod directory", k8sMountPoint}, {"link target directory", mountPoint}})
 			}
 			
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -693,7 +693,8 @@ func checkMountPointIsMounted(mountPoint string, logger logs.Logger, executer ut
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", mountPoint}})
 	}
 	
-	rootDirStat, err := executer.Lstat(mountPoint + "/..")
+	
+	rootDirStat, err := executer.Lstat(filepath.Dir(mountPoint))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", mountPoint}})
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -687,23 +687,26 @@ func getK8sPodsBaseDir(k8sMountPoint string) (string, error ){
 }
 
 func checkSlinkIsActuallyInUse(k8sMountPoint string, logger logs.Logger, executer utils.Executor) (bool, error){
+	logger.info(fmt.Sprintf("k8sMountPoint : %s", k8sMountPoint))
 	evaledSimlink, err := executer.EvalSymlinks(k8sMountPoint)
+	logger.info(fmt.Sprintf("evaed simlink : %s", evaledSimlink))
 	if err != nil {
 		return false, logger.ErrorRet(err, "Failed toedval the symlink.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
 	}
 	slinkStat, err := executer.Stat(evaledSimlink)
+	logger.info(fmt.Sprintf("slinkStat : %s", slinkStat))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from k8s slink file.", logs.Args{{"k8sMountPoint", k8sMountPoint}})
 	}
 	
 	rootDirStat, err := executer.Lstat(evaledSimlink + "/..")
+	logger.info(fmt.Sprintf("rootDirStat : %s", rootDirStat))
 	if err != nil{
 		return false, logger.ErrorRet(err, "Failed to get stat from root directory.", logs.Args{{"directory", k8sMountPoint}})
 	}
-	logger.Info(fmt.Sprintf("slinkStat.Sys() : %s , rootDirStat.Sys() : %s , slinkStat.Sys().(*syscall.Stat_t) : %s , rootDirStat.Sys().(*syscall.Stat_t) : %s ",
-	slinkStat.Sys(), rootDirStat.Sys(), slinkStat.Sys().(*syscall.Stat_t), rootDirStat.Sys().(*syscall.Stat_t) ))
+	//logger.Info(fmt.Sprintf("slinkStat.Sys() : %s , rootDirStat.Sys() : %s , slinkStat.Sys().(*syscall.Stat_t) : %s , rootDirStat.Sys().(*syscall.Stat_t) : %s ",
+	//slinkStat.Sys(), rootDirStat.Sys(), slinkStat.Sys().(*syscall.Stat_t), rootDirStat.Sys().(*syscall.Stat_t) ))
 	logger.Info(fmt.Sprintf("slinkStat.Sys().(*syscall.Stat_t).Dev : %s  ,    rootDirStat.Sys().(*syscall.Stat_t).Dev : %s", slinkStat.Sys().(*syscall.Stat_t).Dev,rootDirStat.Sys().(*syscall.Stat_t).Dev ))
-	
 	
 	if slinkStat.Sys().(*syscall.Stat_t).Dev != rootDirStat.Sys().(*syscall.Stat_t).Dev {
 		return true, nil

--- a/glide.yaml
+++ b/glide.yaml
@@ -110,7 +110,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: 3835cb84683fbcedf343b37b0d61673fce796773
+  version: 3bb8f053e03ee78acab907e8320d3e003ef740f3
   subpackages:
   - remote
   - resources


### PR DESCRIPTION
in this PR the issue that is solved is the following:
as part of the mount there is a check made to see if there are any solf links pointing to the desired mount point ( to /ubiquity/WWN) -this is needed in order to not allow 2 pods to be attached to the same PVC. 
an issue may accur when one of those soft links  is not actually active (for example of a pod  moving to another node in the cluster and back to the original one due to shutdowns) - this is what this PR solves.
beside checking if any soft links exists - a check is made to see if the mount point is mounted. if it is then this is a valid solf link and the current mount should fail. otherwise the current mount can continue un-interrupted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/265)
<!-- Reviewable:end -->
