### PR TITLE
UB-1731 - update the yaml files to point to new cert location mount

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -110,7 +110,7 @@ import:
   subpackages:
   - lib
 - package: github.com/IBM/ubiquity
-  version: f37a22295ddae4d31e70209177df993e9d81fc5a
+  version: 3d199e2bb3a36ebe5615923b9015bc0d3f1a5cbb
   subpackages:
   - remote
   - resources

--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-deployment.yml
@@ -47,7 +47,7 @@ spec:
             subPath: "ibm-ubiquity"
 {{- if eq .Values.genericConfig.connectionInfo.sslMode "verify-full" }}
           - name: ubiquity-db-private-certificate
-            mountPath: /var/lib/postgresql/ssl/private/
+            mountPath: /var/lib/postgresql/ssl/provided/
 {{- end }}
 
       volumes:

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-db-deployment.yml
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/yamls/ubiquity-db-deployment.yml
@@ -43,7 +43,7 @@ spec:
             subPath: "ibm-ubiquity"
 # Certificate Set : use the below volumeMounts only if predefine certificate given
 # Cert #          - name: ubiquity-db-private-certificate
-# Cert #            mountPath: /var/lib/postgresql/ssl/private/
+# Cert #            mountPath: /var/lib/postgresql/ssl/provided/
       volumes:
       - name: ibm-ubiquity-db
         persistentVolumeClaim:


### PR DESCRIPTION
Fix description:

- The mount point is changed to a different folder - ssl/provided - change is in K8s yaml files
- If the private key and certificate are provided through a secret, they will be copied to the ssl/private folder from the ssl/provided folder and then the owner and file mod is changed (in ubiquity github)

related to https://github.com/IBM/ubiquity/pull/274 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity-k8s/266)
<!-- Reviewable:end -->
