### PR TITLE
UB-1614 Upgrade from non-chart to chart

### DIFF
--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-db-pvc.yml
@@ -1,3 +1,4 @@
+{{- if not .Values.ubiquityDb.persistence.useExistingPv }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -15,3 +16,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.ubiquityDb.persistence.pvSize | quote  }}
+{{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -84,6 +84,10 @@ ubiquityDb:
     pvName: ibm-ubiquity-db
     pvSize: 20Gi
 
+    ## Set this param to true if you want to use an existing PV as Ubiquity database PV.
+    ## Warning: Use it only when you want to upgrade Ubiquity from old version installed by script to the latest version.
+    # useExistingPv:
+
     storageClass:
       # Parameters to create the first storage class that is also to be used by Ubiquity for ibm-ubiquity-db PVC.
       # Note: The default reclaimPolicy is Delete. Can be changed manually if needed.

--- a/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_uninstall.sh
+++ b/scripts/installer-for-ibm-storage-enabler-for-containers/ubiquity_uninstall.sh
@@ -108,12 +108,13 @@ if kubectl get $nsf deployment ubiquity-db >/dev/null 2>&1; then
     wait_for_item_to_delete deployment ubiquity-db 10 4 "" $NS
     wait_for_item_to_delete pod "ubiquity-db-" 10 4 regex $NS # to match the prefix of the pod
 fi
-$kubectl_delete -f ${YML_DIR}/ubiquity-db-pvc.yml
-echo "Waiting for PVC ${UBIQUITY_DB_PVC_NAME} to be deleted, before deleting Ubiquity and Provisioner."
-wait_for_item_to_delete pvc ${UBIQUITY_DB_PVC_NAME} 10 3 "" $NS
-pvname=`kubectl get -n ubiquity cm/ubiquity-configmap -o jsonpath="{.data['IBM-UBIQUITY-DB-PV-NAME']}"`
-echo "Waiting for PV $pvname to be deleted, before deleting Ubiquity and Provisioner."
-[ -n "$pvname" ] && wait_for_item_to_delete pv $pvname 10 3 "" $NS
+# keep the ubiquity-db PVC for upgrade later.
+# $kubectl_delete -f ${YML_DIR}/ubiquity-db-pvc.yml
+# echo "Waiting for PVC ${UBIQUITY_DB_PVC_NAME} to be deleted, before deleting Ubiquity and Provisioner."
+# wait_for_item_to_delete pvc ${UBIQUITY_DB_PVC_NAME} 10 3 "" $NS
+# pvname=`kubectl get -n ubiquity cm/ubiquity-configmap -o jsonpath="{.data['IBM-UBIQUITY-DB-PV-NAME']}"`
+# echo "Waiting for PV $pvname to be deleted, before deleting Ubiquity and Provisioner."
+# [ -n "$pvname" ] && wait_for_item_to_delete pv $pvname 10 3 "" $NS
 
 # Second phase: Delete all the stateless components
 $kubectl_delete -f ${YML_DIR}/storage-class.yml
@@ -136,7 +137,8 @@ fi
 $kubectl_delete -f $YML_DIR/ubiquity-k8s-provisioner-clusterrolebindings.yml
 $kubectl_delete -f $YML_DIR/ubiquity-k8s-provisioner-clusterroles.yml
 $kubectl_delete -f $YML_DIR/ubiquity-k8s-provisioner-serviceaccount.yml
-$kubectl_delete -f $YML_DIR/ubiquity-namespace.yml
+# keep the namespace, otherwise the ubiquity-db PVC will be deleted.
+# $kubectl_delete -f $YML_DIR/ubiquity-namespace.yml
 
 echo ""
 echo "\"$PRODUCT_NAME\" uninstall finished."


### PR DESCRIPTION
Support upgrading from non-chart version to chart version, including:
1. change old uninstall script to keep the ubiquity-db PVC
2. add a new param useExistingPv in values.yaml, and create pvc only when it is not set or the value is false

How to upgrade from 2.0 to 2.1:
1. uninstall the current version using the uninstallation script, it will delete all the resoruces except the ubiquity-db pvc
2. install new version using "helm install"