### PR TITLE
UB-1711 psp support in icp

### DIFF
--- a/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-psp-role-binding.yml
+++ b/helm_chart/ibm_storage_enabler_for_containers/templates/ubiquity-k8s-psp-role-binding.yml
@@ -1,0 +1,18 @@
+{{- if .Values.globalConfig.defaultPodSecurityPolicy }}
+{{- if .Values.globalConfig.defaultPodSecurityPolicy.clusterRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ubiquity-psp-rolebinding
+  labels:
+{{ include "ibm_storage_enabler_for_containers.helmLabels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.globalConfig.defaultPodSecurityPolicy.clusterRole }}
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: "system:serviceaccounts:{{ .Release.Namespace }}"
+{{- end }}
+{{- end }}

--- a/helm_chart/ibm_storage_enabler_for_containers/values.yaml
+++ b/helm_chart/ibm_storage_enabler_for_containers/values.yaml
@@ -152,3 +152,12 @@ globalConfig:
   # SSL verification mode. Allowed values: require (no validation is required) and verify-full (user-provided certificates).
   # SSL mode is set for all communication paths between [flex||provisioner]<->ubiquity<->[SpectrumConnect||SpectrumScale].
   sslMode: require
+
+  ## The default Pod Security Policy if specified. it will be applied to any pods in chart if it does not have its own policy.
+  ## Defining new policies is not support, you must define them in advance or using existing ones, and add one or more policies
+  ## to a role or clusterRole, then give the name of the role or clusterRole here.
+  ## Currently, only clusterRole is supported.
+  # defaultPodSecurityPolicy:
+    ## the name of clusterRole that defines the required policies.
+	## Default value for ICP 3.1.1+ is ibm-anyuid-hostpath-clusterrole
+    # clusterRole: ibm-anyuid-hostpath-clusterrole


### PR DESCRIPTION
1. add new value globalConfig.defaultPodSecurityPolicy.clusterRole
2. add new rolebinding ubiquity-psp-rolebinding to bind the cluterRole to all serviceAccounts in the namespace.